### PR TITLE
Fallback on the configured subject if subject block is missing

### DIFF
--- a/Renderer/Adapter/TwigAdapter.php
+++ b/Renderer/Adapter/TwigAdapter.php
@@ -50,7 +50,20 @@ class TwigAdapter extends AbstractAdapter
             /** @var \Twig_Template $template */
             $template = $this->twig->loadTemplate($email->getTemplate());
 
-            $subject = $template->renderBlock('subject', $data);
+            if($template->hasBlock('subject')){
+                
+                $subject = $template->renderBlock('subject', $data);
+                
+            } 
+            else{
+                
+                $twig = new \Twig_Environment(new \Twig_Loader_Array(array()));
+                
+                $subjectTemplate = $twig->createTemplate($email->getSubject());
+                $subject = $subjectTemplate->render($data);
+                
+            }
+            
             $body = $template->renderBlock('body', $data);
         } else {
             $twig = new \Twig_Environment(new \Twig_Loader_Array(array()));


### PR DESCRIPTION
Add the possibility of taking the subject from configuration if the subject block is not present in the template.

Another possibility would be to allow only the subject or the template in the configuration. (could apply to all adapters without additional conditions in them)
