### PR TITLE
Add alias to enable autowire of SenderInterface

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -27,7 +27,10 @@
             <argument type="service" id="sylius.email_provider" />
             <argument type="service" id="sylius.mailer.default_settings_provider" />
         </service>
-
+     
+        <service id="sylius.email_sender.alias" alias="sylius.email_sender" public="true" />
+        <service id="Sylius\Component\Mailer\Sender\SenderInterface" alias="sylius.email_sender.alias" />
+ 
         <service id="sylius.mailer.default_settings_provider" class="Sylius\Component\Mailer\Provider\DefaultSettingsProvider">
             <argument>%sylius.mailer.sender_name%</argument>
             <argument>%sylius.mailer.sender_address%</argument>


### PR DESCRIPTION
Add alias so dependency injection of SenderInterface will work with autowire.

I'm using SyliusMailerBundle standalone in a Symfony project and needed to add this to my config in order to get autowiring to work.  Perhaps this will save someone else some time and trouble.