### PR TITLE
Default adapters without dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,8 @@
         "symfony/console": "^4.3|^5.0",
         "symfony/swiftmailer-bundle": "^3.1",
         "symfony/twig-bundle": "^4.3|^5.0",
-        "vimeo/psalm": "^3.5"
+        "vimeo/psalm": "^3.5",
+        "matthiasnoback/symfony-dependency-injection-test": "^4.0"
     },
     "replace": {
         "sylius/mailer": "self.version"

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
         "symfony/dependency-injection": "^4.3|^5.0",
         "symfony/framework-bundle": "^4.3|^5.0",
         "symfony/http-kernel": "^4.3|^5.0",
-        "twig/twig": "^2.12"
+        "twig/twig": "^2.12",
+        "webmozart/assert": "^1.6"
     },
     "require-dev": {
         "phpspec/phpspec": "^6.1",

--- a/src/Bundle/DependencyInjection/Configuration.php
+++ b/src/Bundle/DependencyInjection/Configuration.php
@@ -30,8 +30,8 @@ final class Configuration implements ConfigurationInterface
 
         $rootNode
             ->children()
-                ->scalarNode('sender_adapter')->defaultValue('sylius.email_sender.adapter.swiftmailer')->end()
-                ->scalarNode('renderer_adapter')->defaultValue('sylius.email_renderer.adapter.twig')->end()
+                ->scalarNode('sender_adapter')->defaultValue('sylius.email_sender.adapter.default')->end()
+                ->scalarNode('renderer_adapter')->defaultValue('sylius.email_renderer.adapter.default')->end()
             ->end()
         ;
 

--- a/src/Bundle/DependencyInjection/Configuration.php
+++ b/src/Bundle/DependencyInjection/Configuration.php
@@ -30,8 +30,8 @@ final class Configuration implements ConfigurationInterface
 
         $rootNode
             ->children()
-                ->scalarNode('sender_adapter')->defaultValue('sylius.email_sender.adapter.default')->end()
-                ->scalarNode('renderer_adapter')->defaultValue('sylius.email_renderer.adapter.default')->end()
+                ->scalarNode('sender_adapter')->end()
+                ->scalarNode('renderer_adapter')->end()
             ->end()
         ;
 

--- a/src/Bundle/DependencyInjection/SyliusMailerExtension.php
+++ b/src/Bundle/DependencyInjection/SyliusMailerExtension.php
@@ -40,8 +40,8 @@ final class SyliusMailerExtension extends Extension
             $loader->load($configFile);
         }
 
-        $this->configureSenderAdapter($container);
-        $this->configureRendererAdapter($container);
+        $this->configureSenderAdapter($container, $config);
+        $this->configureRendererAdapter($container, $config);
 
         $container->setParameter('sylius.mailer.sender_name', $config['sender']['name']);
         $container->setParameter('sylius.mailer.sender_address', $config['sender']['address']);
@@ -64,7 +64,7 @@ final class SyliusMailerExtension extends Extension
         return $configuration;
     }
 
-    private function configureSenderAdapter(ContainerBuilder $container): void
+    private function configureSenderAdapter(ContainerBuilder $container, array $config): void
     {
         $bundles = $container->getParameter('kernel.bundles');
 
@@ -82,7 +82,7 @@ final class SyliusMailerExtension extends Extension
         $container->setAlias('sylius.email_sender.adapter', $config['sender_adapter'] ?? $defaultSenderAdapter);
     }
 
-    private function configureRendererAdapter(ContainerBuilder $container): void
+    private function configureRendererAdapter(ContainerBuilder $container, array $config): void
     {
         $bundles = $container->getParameter('kernel.bundles');
 

--- a/src/Bundle/DependencyInjection/SyliusMailerExtension.php
+++ b/src/Bundle/DependencyInjection/SyliusMailerExtension.php
@@ -13,10 +13,15 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\MailerBundle\DependencyInjection;
 
+use Sylius\Bundle\MailerBundle\Renderer\Adapter\EmailTwigAdapter;
+use Sylius\Bundle\MailerBundle\Sender\Adapter\SwiftMailerAdapter;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
+use Symfony\Component\DependencyInjection\Reference;
 
 final class SyliusMailerExtension extends Extension
 {
@@ -36,8 +41,8 @@ final class SyliusMailerExtension extends Extension
             $loader->load($configFile);
         }
 
-        $container->setAlias('sylius.email_sender.adapter', $config['sender_adapter']);
-        $container->setAlias('sylius.email_renderer.adapter', $config['renderer_adapter']);
+        $this->configureSenderAdapter($container);
+        $this->configureRendererAdapter($container);
 
         $container->setParameter('sylius.mailer.sender_name', $config['sender']['name']);
         $container->setParameter('sylius.mailer.sender_address', $config['sender']['address']);
@@ -58,5 +63,41 @@ final class SyliusMailerExtension extends Extension
         $container->addObjectResource($configuration);
 
         return $configuration;
+    }
+
+    private function configureSenderAdapter(ContainerBuilder $container): void
+    {
+        $bundles = $container->getParameter('kernel.bundles');
+
+        $defaultSenderAdapter = 'sylius.email_sender.adapter.default';
+        if (array_key_exists('SwiftmailerBundle', $bundles)) {
+            $swiftmailerAdapter = new ChildDefinition('sylius.email_sender.adapter.abstract');
+            $swiftmailerAdapter->setClass(SwiftMailerAdapter::class);
+            $swiftmailerAdapter->setArguments([new Reference('mailer'), new Reference('event_dispatcher')]);
+            $swiftmailerAdapter->setPrivate(false);
+
+            $container->setDefinition('sylius.email_sender.adapter.swiftmailer', $swiftmailerAdapter);
+            $defaultSenderAdapter = 'sylius.email_sender.adapter.swiftmailer';
+        }
+
+        $container->setAlias('sylius.email_sender.adapter', $config['sender_adapter'] ?? $defaultSenderAdapter);
+    }
+
+    private function configureRendererAdapter(ContainerBuilder $container): void
+    {
+        $bundles = $container->getParameter('kernel.bundles');
+
+        $defaultRendererAdapter = 'sylius.email_renderer.adapter.default';
+        if (array_key_exists('TwigBundle', $bundles)) {
+            $twigAdapter = new ChildDefinition('sylius.email_renderer.adapter.abstract');
+            $twigAdapter->setClass(EmailTwigAdapter::class);
+            $twigAdapter->setArguments([new Reference('twig'), new Reference('event_dispatcher')]);
+            $twigAdapter->setPrivate(false);
+
+            $container->setDefinition('sylius.email_renderer.adapter.twig', $twigAdapter);
+            $defaultRendererAdapter = 'sylius.email_renderer.adapter.twig';
+        }
+
+        $container->setAlias('sylius.email_renderer.adapter', $config['renderer_adapter'] ?? $defaultRendererAdapter);
     }
 }

--- a/src/Bundle/DependencyInjection/SyliusMailerExtension.php
+++ b/src/Bundle/DependencyInjection/SyliusMailerExtension.php
@@ -18,7 +18,6 @@ use Sylius\Bundle\MailerBundle\Sender\Adapter\SwiftMailerAdapter;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;

--- a/src/Bundle/Renderer/Adapter/EmailDefaultAdapter.php
+++ b/src/Bundle/Renderer/Adapter/EmailDefaultAdapter.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\MailerBundle\Renderer\Adapter;
+
+use Sylius\Component\Mailer\Model\EmailInterface;
+use Sylius\Component\Mailer\Renderer\Adapter\AbstractAdapter;
+use Sylius\Component\Mailer\Renderer\RenderedEmail;
+
+final class EmailDefaultAdapter extends AbstractAdapter
+{
+    public function render(EmailInterface $email, array $data = []): RenderedEmail
+    {
+        throw new \RuntimeException(sprintf(
+            'You need to configure an adapter to render the email. Take a look at %s (requires "symfony/twig-bundle" library).',
+            EmailTwigAdapter::class
+        ));
+    }
+}

--- a/src/Bundle/Renderer/Adapter/EmailDefaultAdapter.php
+++ b/src/Bundle/Renderer/Adapter/EmailDefaultAdapter.php
@@ -16,9 +16,18 @@ namespace Sylius\Bundle\MailerBundle\Renderer\Adapter;
 use Sylius\Component\Mailer\Model\EmailInterface;
 use Sylius\Component\Mailer\Renderer\Adapter\AbstractAdapter;
 use Sylius\Component\Mailer\Renderer\RenderedEmail;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 final class EmailDefaultAdapter extends AbstractAdapter
 {
+    /** @var EventDispatcherInterface|null */
+    protected $dispatcher;
+
+    public function __construct(?EventDispatcherInterface $dispatcher = null)
+    {
+        $this->dispatcher = $dispatcher;
+    }
+
     public function render(EmailInterface $email, array $data = []): RenderedEmail
     {
         throw new \RuntimeException(sprintf(

--- a/src/Bundle/Resources/config/services.xml
+++ b/src/Bundle/Resources/config/services.xml
@@ -49,11 +49,6 @@
             parent="sylius.email_renderer.adapter.abstract"
             public="true"
         />
-        <service id="sylius.email_renderer.adapter.twig" class="Sylius\Bundle\MailerBundle\Renderer\Adapter\EmailTwigAdapter"
-                 parent="sylius.email_renderer.adapter.abstract" public="true">
-            <argument type="service" id="twig" />
-            <argument type="service" id="event_dispatcher" />
-        </service>
 
         <service id="sylius.email_sender.adapter.abstract" class="Sylius\Component\Mailer\Sender\Adapter\AbstractAdapter" abstract="true">
             <call method="setEventDispatcher">
@@ -66,10 +61,5 @@
             parent="sylius.email_sender.adapter.abstract"
             public="true"
         />
-        <service id="sylius.email_sender.adapter.swiftmailer" class="Sylius\Bundle\MailerBundle\Sender\Adapter\SwiftMailerAdapter"
-                 parent="sylius.email_sender.adapter.abstract" public="true">
-            <argument type="service" id="mailer" />
-            <argument type="service" id="event_dispatcher" />
-        </service>
     </services>
 </container>

--- a/src/Bundle/Resources/config/services.xml
+++ b/src/Bundle/Resources/config/services.xml
@@ -43,6 +43,12 @@
                 <argument type="service" id="event_dispatcher" />
             </call>
         </service>
+        <service
+            id="sylius.email_renderer.adapter.default"
+            class="Sylius\Bundle\MailerBundle\Renderer\Adapter\EmailDefaultAdapter"
+            parent="sylius.email_renderer.adapter.abstract"
+            public="true"
+        />
         <service id="sylius.email_renderer.adapter.twig" class="Sylius\Bundle\MailerBundle\Renderer\Adapter\EmailTwigAdapter"
                  parent="sylius.email_renderer.adapter.abstract" public="true">
             <argument type="service" id="twig" />
@@ -54,6 +60,12 @@
                 <argument type="service" id="event_dispatcher" />
             </call>
         </service>
+        <service
+            id="sylius.email_sender.adapter.default"
+            class="Sylius\Bundle\MailerBundle\Sender\Adapter\DefaultAdapter"
+            parent="sylius.email_sender.adapter.abstract"
+            public="true"
+        />
         <service id="sylius.email_sender.adapter.swiftmailer" class="Sylius\Bundle\MailerBundle\Sender\Adapter\SwiftMailerAdapter"
                  parent="sylius.email_sender.adapter.abstract" public="true">
             <argument type="service" id="mailer" />

--- a/src/Bundle/Sender/Adapter/DefaultAdapter.php
+++ b/src/Bundle/Sender/Adapter/DefaultAdapter.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\MailerBundle\Sender\Adapter;
+
+use Sylius\Component\Mailer\Model\EmailInterface;
+use Sylius\Component\Mailer\Renderer\RenderedEmail;
+use Sylius\Component\Mailer\Sender\Adapter\AbstractAdapter;
+
+final class DefaultAdapter extends AbstractAdapter
+{
+    public function send(
+        array $recipients,
+        string $senderAddress,
+        string $senderName,
+        RenderedEmail $renderedEmail,
+        EmailInterface $email,
+        array $data,
+        array $attachments = [],
+        array $replyTo = []
+    ): void {
+        throw new \RuntimeException(sprintf(
+            'You need to configure an adapter to send the email. Take a look at %s (requires "symfony/swiftmailer-bundle" library).',
+            SwiftMailerAdapter::class
+        ));
+    }
+}

--- a/src/Bundle/Sender/Adapter/DefaultAdapter.php
+++ b/src/Bundle/Sender/Adapter/DefaultAdapter.php
@@ -16,9 +16,18 @@ namespace Sylius\Bundle\MailerBundle\Sender\Adapter;
 use Sylius\Component\Mailer\Model\EmailInterface;
 use Sylius\Component\Mailer\Renderer\RenderedEmail;
 use Sylius\Component\Mailer\Sender\Adapter\AbstractAdapter;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 final class DefaultAdapter extends AbstractAdapter
 {
+    /** @var EventDispatcherInterface|null */
+    protected $dispatcher;
+
+    public function __construct(?EventDispatcherInterface $dispatcher = null)
+    {
+        $this->dispatcher = $dispatcher;
+    }
+
     public function send(
         array $recipients,
         string $senderAddress,

--- a/src/Bundle/spec/Renderer/Adapter/EmailDefaultAdapterSpec.php
+++ b/src/Bundle/spec/Renderer/Adapter/EmailDefaultAdapterSpec.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace spec\Sylius\Bundle\MailerBundle\Renderer\Adapter;
+
+use PhpSpec\ObjectBehavior;
+use Sylius\Bundle\MailerBundle\Renderer\Adapter\EmailTwigAdapter;
+use Sylius\Component\Mailer\Model\EmailInterface;
+use Sylius\Component\Mailer\Renderer\Adapter\AbstractAdapter;
+
+final class EmailDefaultAdapterSpec extends ObjectBehavior
+{
+    function it_is_an_adapter(): void
+    {
+        $this->shouldHaveType(AbstractAdapter::class);
+    }
+
+    function it_throws_an_exception_about_not_configured_email_renderer_adapter(EmailInterface $email): void
+    {
+        $this
+            ->shouldThrow(new \RuntimeException(sprintf(
+                'You need to configure an adapter to render the email. Take a look at %s (requires "symfony/twig-bundle" library).',
+                EmailTwigAdapter::class
+            )))
+            ->during('render', [$email, []])
+        ;
+    }
+}

--- a/src/Bundle/spec/Sender/Adapter/DefaultAdapterSpec.php
+++ b/src/Bundle/spec/Sender/Adapter/DefaultAdapterSpec.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace spec\Sylius\Bundle\MailerBundle\Sender\Adapter;
+
+use PhpSpec\ObjectBehavior;
+use Sylius\Bundle\MailerBundle\Sender\Adapter\SwiftMailerAdapter;
+use Sylius\Component\Mailer\Model\EmailInterface;
+use Sylius\Component\Mailer\Renderer\RenderedEmail;
+use Sylius\Component\Mailer\Sender\Adapter\AbstractAdapter;
+
+final class DefaultAdapterSpec extends ObjectBehavior
+{
+    function it_is_an_adapter(): void
+    {
+        $this->shouldHaveType(AbstractAdapter::class);
+    }
+
+    function it_throws_an_exception_about_not_configured_email_sender_adapter(
+        EmailInterface $email,
+        RenderedEmail $renderedEmail
+    ): void {
+        $this
+            ->shouldThrow(new \RuntimeException(sprintf(
+                'You need to configure an adapter to send the email. Take a look at %s (requires "symfony/swiftmailer-bundle" library).',
+                SwiftMailerAdapter::class
+            )))
+            ->during('send', [['pawel@sylius.com'], 'arnaud@sylius.com', 'arnaud', $renderedEmail, $email, []])
+        ;
+    }
+}

--- a/src/Bundle/test/src/Tests/DependencyInjection/SyliusMailerExtensionTest.php
+++ b/src/Bundle/test/src/Tests/DependencyInjection/SyliusMailerExtensionTest.php
@@ -1,0 +1,105 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\MailerBundle\test\src\Tests\DependencyInjection;
+
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
+use Sylius\Bundle\MailerBundle\DependencyInjection\SyliusMailerExtension;
+use Sylius\Bundle\MailerBundle\Renderer\Adapter\EmailDefaultAdapter;
+use Sylius\Bundle\MailerBundle\Renderer\Adapter\EmailTwigAdapter;
+use Sylius\Bundle\MailerBundle\Sender\Adapter\DefaultAdapter;
+use Sylius\Bundle\MailerBundle\Sender\Adapter\SwiftMailerAdapter;
+use Symfony\Bundle\SwiftmailerBundle\SwiftmailerBundle;
+use Symfony\Bundle\TwigBundle\TwigBundle;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Twig\Environment;
+
+final class SyliusMailerExtensionTest extends AbstractExtensionTestCase
+{
+    /** @test */
+    public function it_configures_mailer_adapters_and_sender_with_default_data(): void
+    {
+        $this->mockService('event_dispatcher', EventDispatcher::class);
+
+        $this->container->setParameter('kernel.bundles', []);
+
+        $this->load();
+        $this->compile();
+
+        $this->assertContainerBuilderHasParameter('sylius.mailer.sender_name', 'Example.com Store');
+        $this->assertContainerBuilderHasParameter('sylius.mailer.sender_address', 'no-reply@example.com');
+
+        $this->assertContainerBuilderHasService('sylius.email_sender.adapter.default', DefaultAdapter::class);
+        $this->assertContainerBuilderHasAlias('sylius.email_sender.adapter', 'sylius.email_sender.adapter.default');
+
+        $this->assertContainerBuilderHasService('sylius.email_renderer.adapter.default', EmailDefaultAdapter::class);
+        $this->assertContainerBuilderHasAlias('sylius.email_renderer.adapter', 'sylius.email_renderer.adapter.default');
+    }
+
+    /** @test */
+    public function it_configures_mailer_adapters_and_sender_with_custom_sender_data(): void
+    {
+        $this->mockService('event_dispatcher', EventDispatcher::class);
+        $this->container->setParameter('kernel.bundles', []);
+
+        $this->load(['sender' => ['name' => 'John Doe', 'address' => 'john@doe.com']]);
+        $this->compile();
+
+        $this->assertContainerBuilderHasParameter('sylius.mailer.sender_name', 'John Doe');
+        $this->assertContainerBuilderHasParameter('sylius.mailer.sender_address', 'john@doe.com');
+
+        $this->assertContainerBuilderHasService('sylius.email_sender.adapter.default', DefaultAdapter::class);
+        $this->assertContainerBuilderHasAlias('sylius.email_sender.adapter', 'sylius.email_sender.adapter.default');
+
+        $this->assertContainerBuilderHasService('sylius.email_renderer.adapter.default', EmailDefaultAdapter::class);
+        $this->assertContainerBuilderHasAlias('sylius.email_renderer.adapter', 'sylius.email_renderer.adapter.default');
+    }
+
+    /** @test */
+    public function it_configures_twig_and_swiftmailer_adapters_if_they_are_available(): void
+    {
+        $this->mockService('event_dispatcher', EventDispatcher::class);
+        $this->mockService('mailer', \Swift_Mailer::class);
+        $this->mockService('twig', Environment::class);
+
+        $this->container->setParameter(
+            'kernel.bundles',
+            ['SwiftmailerBundle' => SwiftmailerBundle::class, 'TwigBundle' => TwigBundle::class]
+        );
+
+        $this->load();
+        $this->compile();
+
+        $this->assertContainerBuilderHasParameter('sylius.mailer.sender_name', 'Example.com Store');
+        $this->assertContainerBuilderHasParameter('sylius.mailer.sender_address', 'no-reply@example.com');
+
+        $this->assertContainerBuilderHasService('sylius.email_sender.adapter.swiftmailer', SwiftMailerAdapter::class);
+        $this->assertContainerBuilderHasAlias('sylius.email_sender.adapter', 'sylius.email_sender.adapter.swiftmailer');
+
+        $this->assertContainerBuilderHasService('sylius.email_renderer.adapter.twig', EmailTwigAdapter::class);
+        $this->assertContainerBuilderHasAlias('sylius.email_renderer.adapter', 'sylius.email_renderer.adapter.twig');
+    }
+
+    protected function getContainerExtensions(): array
+    {
+        return [new SyliusMailerExtension()];
+    }
+
+    private function mockService(string $id, string $class): void
+    {
+        $this->container->setDefinition(
+            $id, (new Definition())->setClass(self::getMockClass($class))->setAutoconfigured(true)
+        );
+    }
+}


### PR DESCRIPTION
Current default adapters (both for sending and rendering emails) reassumed symfony bundles that are only required in `dev`. Even though they're usually there, it was right now not possible to use this bundle just after installation in, for example, a new Symfony-based project.

Changes:
- register `SwiftMailerAdapter` and `EmailTwigAdapter` (and use them by default) only if required bundles are installed
- new default drivers, that throws exceptions about the need to configure adapters