### PR TITLE
Fix missing subject bug

### DIFF
--- a/src/Component/Provider/EmailProvider.php
+++ b/src/Component/Provider/EmailProvider.php
@@ -50,7 +50,11 @@ final class EmailProvider implements EmailProviderInterface
         $configuration = $this->configuration[$code];
 
         $email->setCode($code);
-        $email->setSubject($configuration['subject']);
+
+        if (isset($configuration['subject'])) {
+            $email->setSubject($configuration['subject']);
+        }
+
         $email->setTemplate($configuration['template']);
 
         if (isset($configuration['enabled']) && false === $configuration['enabled']) {


### PR DESCRIPTION
In #9 we have deprecated `subject` config, but we haven't allowed for lack of it in the first place. 

Ref. https://github.com/Sylius/SyliusMailerBundle/blob/master/src/Bundle/DependencyInjection/Configuration.php#L58-L60