### PR TITLE
Document array structures

### DIFF
--- a/src/Component/Sender/Adapter/AdapterInterface.php
+++ b/src/Component/Sender/Adapter/AdapterInterface.php
@@ -18,6 +18,11 @@ use Sylius\Component\Mailer\Renderer\RenderedEmail;
 
 interface AdapterInterface
 {
+    /**
+     * @param string[] $recipients A list of email addresses to receive the message.
+     * @param string[] $attachments A list of file paths to attach to the message.
+     * @param string[] $replyTo A list of email addresses to set as the Reply-To address for the message.
+     */
     public function send(
         array $recipients,
         string $senderAddress,

--- a/src/Component/Sender/SenderInterface.php
+++ b/src/Component/Sender/SenderInterface.php
@@ -15,5 +15,10 @@ namespace Sylius\Component\Mailer\Sender;
 
 interface SenderInterface
 {
+    /**
+     * @param string[] $recipients A list of email addresses to receive the message.
+     * @param string[] $attachments A list of file paths to attach to the message.
+     * @param string[] $replyTo A list of email addresses to set as the Reply-To address for the message.
+     */
     public function send(string $code, array $recipients, array $data = [], array $attachments = [], array $replyTo = []): void;
 }


### PR DESCRIPTION
Adds doc blocks explaining the required array structures for the `$recipients`, `$attachments`, and `$replyTo` arguments.

The `$recipients` and `$replyTo` arguments, based on the current SwiftMailer implementation and the proposed Symfony Mailer integration, can only work as a list of email addresses.  Trying to use other array structures (such as key-value pairs that the SwiftMailer API supports or `Address` objects or formatted strings (i.e. `Name <email@example.com>`) that Symfony Mailer supports) results in code being hard coupled to the underlying interface implementation.

Similarly for the `$attachments` argument, the adapters explicitly call a method on their underlying component that expects an existing file path.