### PR TITLE
[Sender] Assert recipient emails are always not empty strings

### DIFF
--- a/src/Component/Sender/Sender.php
+++ b/src/Component/Sender/Sender.php
@@ -17,6 +17,7 @@ use Sylius\Component\Mailer\Provider\DefaultSettingsProviderInterface;
 use Sylius\Component\Mailer\Provider\EmailProviderInterface;
 use Sylius\Component\Mailer\Renderer\Adapter\AdapterInterface as RendererAdapterInterface;
 use Sylius\Component\Mailer\Sender\Adapter\AdapterInterface as SenderAdapterInterface;
+use Webmozart\Assert\Assert;
 
 final class Sender implements SenderInterface
 {
@@ -45,6 +46,8 @@ final class Sender implements SenderInterface
      */
     public function send(string $code, array $recipients, array $data = [], array $attachments = [], array $replyTo = []): void
     {
+        Assert::allStringNotEmpty($recipients);
+
         $email = $this->provider->getEmail($code);
 
         if (!$email->isEnabled()) {

--- a/src/Component/Sender/SenderInterface.php
+++ b/src/Component/Sender/SenderInterface.php
@@ -16,7 +16,7 @@ namespace Sylius\Component\Mailer\Sender;
 interface SenderInterface
 {
     /**
-     * @param string[] $recipients A list of email addresses to receive the message.
+     * @param string[]|null[] $recipients A list of email addresses to receive the message. Providing null or empty string in the list of recipients is deprecated and will be removed in SyliusMailerBundle 2.0
      * @param string[] $attachments A list of file paths to attach to the message.
      * @param string[] $replyTo A list of email addresses to set as the Reply-To address for the message.
      */

--- a/src/Component/spec/Sender/SenderSpec.php
+++ b/src/Component/spec/Sender/SenderSpec.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace spec\Sylius\Component\Mailer\Sender;
 
 use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
 use Sylius\Component\Mailer\Model\EmailInterface;
 use Sylius\Component\Mailer\Provider\DefaultSettingsProviderInterface;
 use Sylius\Component\Mailer\Provider\EmailProviderInterface;
@@ -65,5 +66,28 @@ final class SenderSpec extends ObjectBehavior
         $senderAdapter->send(['john@example.com'], 'mail@sylius.com', 'Sylius Mailer', null, $email, [], [], [])->shouldNotBeCalled();
 
         $this->send('bar', ['john@example.com'], ['foo' => 2], []);
+    }
+
+    function it_throws_an_exception_if_wrong_value_is_provided_as_recipient_email(
+        RendererAdapterInterface $rendererAdapter,
+        SenderAdapterInterface $senderAdapter
+    ): void {
+        $rendererAdapter->render(Argument::any())->shouldNotBeCalled();
+        $senderAdapter->send(Argument::any())->shouldNotBeCalled();
+
+        $this->shouldThrow(\InvalidArgumentException::class)->during(
+            'send',
+            ['bar', ['john@example.com', null], ['foo' => 2], []],
+        );
+
+        $this->shouldThrow(\InvalidArgumentException::class)->during(
+            'send',
+            ['bar', [5], ['foo' => 2], []],
+        );
+
+        $this->shouldThrow(\InvalidArgumentException::class)->during(
+            'send',
+            ['bar', [''], ['foo' => 2], []],
+        );
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

In Sylius our "getEmail" contract on "Customer" is saying that email can be null. Of course, we should never pass null to the sender, however, the psalm is complaining that we've changed rules. with the #113. 

I'm in favour of enforcing this rule, but rather in runtime to keep all the builds green. We can change it with SyliusMailer 2.0

Related psalm test: https://psalm.dev/r/18ab1bda24