### PR TITLE
Upgrade ECS configuration to fix the build

### DIFF
--- a/ecs.php
+++ b/ecs.php
@@ -4,14 +4,13 @@ use PhpCsFixer\Fixer\ClassNotation\VisibilityRequiredFixer;
 use PhpCsFixer\Fixer\Comment\HeaderCommentFixer;
 use PhpCsFixer\Fixer\Phpdoc\PhpdocTagTypeFixer;
 use SlevomatCodingStandard\Sniffs\Commenting\InlineDocCommentDeclarationSniff;
-use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-use Symplify\EasyCodingStandard\ValueObject\Option;
+use Symplify\EasyCodingStandard\Config\ECSConfig;
 
-return static function (ContainerConfigurator $containerConfigurator): void
+return static function (ECSConfig $config): void
 {
-    $containerConfigurator->import('vendor/sylius-labs/coding-standard/ecs.php');
+    $config->import('vendor/sylius-labs/coding-standard/ecs.php');
 
-    $containerConfigurator->services()->set(HeaderCommentFixer::class)->call('configure', [[
+    $config->ruleWithConfiguration(HeaderCommentFixer::class, [
         'location' => 'after_open',
         'header' =>
             'This file is part of the Sylius package.
@@ -20,9 +19,9 @@ return static function (ContainerConfigurator $containerConfigurator): void
 
 For the full copyright and license information, please view the LICENSE
 file that was distributed with this source code.',
-    ]]);
+    ]);
 
-    $containerConfigurator->parameters()->set(Option::SKIP, [
+    $config->skip([
         PhpdocTagTypeFixer::class,
         InlineDocCommentDeclarationSniff::class . '.MissingVariable',
         VisibilityRequiredFixer::class => ['*Spec.php'],

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -8,7 +8,7 @@ parameters:
     checkMissingIterableValueType: false
     reportUnmatchedIgnoredErrors: false
 
-    excludes_analyse:
+    excludePaths:
         - %currentWorkingDirectory%/src/Bundle/DependencyInjection/Configuration.php
         - %currentWorkingDirectory%/src/Bundle/spec/*
         - %currentWorkingDirectory%/src/Bundle/test/*


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets |
| License         | MIT

I've upgraded the ECS configuration (it was failing the build) as well as changed deprecated key in PHPStan config 🖖 