### PR TITLE
Allow to specify CC and BCC in sender

### DIFF
--- a/ecs.php
+++ b/ecs.php
@@ -2,6 +2,7 @@
 
 use PhpCsFixer\Fixer\ClassNotation\VisibilityRequiredFixer;
 use PhpCsFixer\Fixer\Comment\HeaderCommentFixer;
+use PhpCsFixer\Fixer\Phpdoc\NoSuperfluousPhpdocTagsFixer;
 use PhpCsFixer\Fixer\Phpdoc\PhpdocTagTypeFixer;
 use SlevomatCodingStandard\Sniffs\Commenting\InlineDocCommentDeclarationSniff;
 use Symplify\EasyCodingStandard\Config\ECSConfig;
@@ -25,6 +26,7 @@ file that was distributed with this source code.',
         PhpdocTagTypeFixer::class,
         InlineDocCommentDeclarationSniff::class . '.MissingVariable',
         VisibilityRequiredFixer::class => ['*Spec.php'],
+        NoSuperfluousPhpdocTagsFixer::class => ['src/Component/Sender/SenderInterface.php'],
         '**/var/*',
         'src/Bundle/test/app/AppKernel.php',
     ]);

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -26,3 +26,5 @@ parameters:
         - '/Method Symfony\\Contracts\\EventDispatcher\\EventDispatcherInterface::dispatch\(\) invoked with 2 parameters, 1 required\./'
         - '/Cannot call method has\(\) on object\|null/'
         - '/Property Sylius\\Component\\Mailer\\Model\\Email\:\:\$id is never written\, only read\./'
+        - '/PHPDoc tag \@param references unknown parameter\: \$bccRecipients/'
+        - '/PHPDoc tag \@param references unknown parameter\: \$ccRecipients/'

--- a/psalm.xml
+++ b/psalm.xml
@@ -17,6 +17,12 @@
     </projectFiles>
 
     <issueHandlers>
+        <InvalidDocblockParamName>
+            <errorLevel type="suppress">
+                <file name="src/Component/Sender/SenderInterface.php" />
+            </errorLevel>
+        </InvalidDocblockParamName>
+
         <PossiblyNullReference>
             <errorLevel type="suppress">
                 <file name="src/Bundle/DependencyInjection/Configuration.php" />

--- a/src/Bundle/Sender/Adapter/DefaultAdapter.php
+++ b/src/Bundle/Sender/Adapter/DefaultAdapter.php
@@ -43,4 +43,22 @@ final class DefaultAdapter extends AbstractAdapter
             SymfonyMailerAdapter::class,
         ));
     }
+
+    public function sendWithCC(
+        array $recipients,
+        string $senderAddress,
+        string $senderName,
+        RenderedEmail $renderedEmail,
+        EmailInterface $email,
+        array $data,
+        array $attachments = [],
+        array $replyTo = [],
+        array $ccRecipients = [],
+        array $bccRecipients = []
+    ): void {
+        throw new \RuntimeException(sprintf(
+            'You need to configure an adapter to send the email. Take a look at %s (requires "symfony/mailer" library).',
+            SymfonyMailerAdapter::class
+        ));
+    }
 }

--- a/src/Bundle/Sender/Adapter/DefaultAdapter.php
+++ b/src/Bundle/Sender/Adapter/DefaultAdapter.php
@@ -54,11 +54,11 @@ final class DefaultAdapter extends AbstractAdapter
         array $attachments = [],
         array $replyTo = [],
         array $ccRecipients = [],
-        array $bccRecipients = []
+        array $bccRecipients = [],
     ): void {
         throw new \RuntimeException(sprintf(
             'You need to configure an adapter to send the email. Take a look at %s (requires "symfony/mailer" library).',
-            SymfonyMailerAdapter::class
+            SymfonyMailerAdapter::class,
         ));
     }
 }

--- a/src/Bundle/Sender/Adapter/SwiftMailerAdapter.php
+++ b/src/Bundle/Sender/Adapter/SwiftMailerAdapter.php
@@ -55,13 +55,16 @@ class SwiftMailerAdapter extends AbstractAdapter
         array $data,
         array $attachments = [],
         array $replyTo = [],
+        array $ccRecipients = [],
+        array $bccRecipients = []
     ): void {
         $message = (new \Swift_Message())
             ->setSubject($renderedEmail->getSubject())
             ->setFrom([$senderAddress => $senderName])
             ->setTo($recipients)
-            ->setReplyTo($replyTo)
-        ;
+            ->setCc($ccRecipients)
+            ->setBcc($bccRecipients)
+            ->setReplyTo($replyTo);
 
         $message->setBody($renderedEmail->getBody(), 'text/html');
 

--- a/src/Bundle/Sender/Adapter/SwiftMailerAdapter.php
+++ b/src/Bundle/Sender/Adapter/SwiftMailerAdapter.php
@@ -55,10 +55,17 @@ class SwiftMailerAdapter extends AbstractAdapter implements CcAwareAdapterInterf
         EmailInterface $email,
         array $data,
         array $attachments = [],
-        array $replyTo = []
+        array $replyTo = [],
     ): void {
         $this->sendMessage(
-            $renderedEmail, $senderAddress, $senderName, $recipients, $replyTo, $attachments, $email, $data
+            $renderedEmail,
+            $senderAddress,
+            $senderName,
+            $recipients,
+            $replyTo,
+            $attachments,
+            $email,
+            $data,
         );
     }
 
@@ -72,10 +79,19 @@ class SwiftMailerAdapter extends AbstractAdapter implements CcAwareAdapterInterf
         array $attachments = [],
         array $replyTo = [],
         array $ccRecipients = [],
-        array $bccRecipients = []
+        array $bccRecipients = [],
     ): void {
         $this->sendMessage(
-            $renderedEmail, $senderAddress, $senderName, $recipients, $replyTo, $attachments, $email, $data, $ccRecipients, $bccRecipients
+            $renderedEmail,
+            $senderAddress,
+            $senderName,
+            $recipients,
+            $replyTo,
+            $attachments,
+            $email,
+            $data,
+            $ccRecipients,
+            $bccRecipients,
         );
     }
 
@@ -89,7 +105,7 @@ class SwiftMailerAdapter extends AbstractAdapter implements CcAwareAdapterInterf
         EmailInterface $email,
         array $data,
         array $ccRecipients = [],
-        array $bccRecipients = []
+        array $bccRecipients = [],
     ): void {
         $message = (new \Swift_Message())
             ->setSubject($renderedEmail->getSubject())

--- a/src/Bundle/Sender/Adapter/SymfonyMailerAdapter.php
+++ b/src/Bundle/Sender/Adapter/SymfonyMailerAdapter.php
@@ -103,12 +103,8 @@ final class SymfonyMailerAdapter extends AbstractAdapter implements CcAwareAdapt
             ->html($renderedEmail->getBody())
         ;
 
-        if (!empty($ccRecipients)) {
-            $message->addCc(...$ccRecipients);
-        }
-        if (!empty($bccRecipients)) {
-            $message->addBcc(...$bccRecipients);
-        }
+        $message->addCc(...$ccRecipients);
+        $message->addBcc(...$bccRecipients);
 
         foreach ($attachments as $attachment) {
             $message->attachFromPath($attachment);

--- a/src/Bundle/Sender/Adapter/SymfonyMailerAdapter.php
+++ b/src/Bundle/Sender/Adapter/SymfonyMailerAdapter.php
@@ -46,7 +46,14 @@ final class SymfonyMailerAdapter extends AbstractAdapter implements CcAwareAdapt
         array $replyTo = [],
     ): void {
         $this->sendMessage(
-            $renderedEmail, $senderAddress, $senderName, $recipients, $replyTo, $attachments, $email, $data
+            $renderedEmail,
+            $senderAddress,
+            $senderName,
+            $recipients,
+            $replyTo,
+            $attachments,
+            $email,
+            $data,
         );
     }
 
@@ -63,7 +70,16 @@ final class SymfonyMailerAdapter extends AbstractAdapter implements CcAwareAdapt
         array $bccRecipients = [],
     ): void {
         $this->sendMessage(
-            $renderedEmail, $senderAddress, $senderName, $recipients, $replyTo, $attachments, $email, $data, $ccRecipients, $bccRecipients
+            $renderedEmail,
+            $senderAddress,
+            $senderName,
+            $recipients,
+            $replyTo,
+            $attachments,
+            $email,
+            $data,
+            $ccRecipients,
+            $bccRecipients,
         );
     }
 

--- a/src/Bundle/Sender/Adapter/SymfonyMailerAdapter.php
+++ b/src/Bundle/Sender/Adapter/SymfonyMailerAdapter.php
@@ -17,12 +17,13 @@ use Sylius\Component\Mailer\Event\EmailSendEvent;
 use Sylius\Component\Mailer\Model\EmailInterface;
 use Sylius\Component\Mailer\Renderer\RenderedEmail;
 use Sylius\Component\Mailer\Sender\Adapter\AbstractAdapter;
+use Sylius\Component\Mailer\Sender\Adapter\CcAwareAdapterInterface;
 use Sylius\Component\Mailer\SyliusMailerEvents;
 use Symfony\Component\Mailer\MailerInterface;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
 
-final class SymfonyMailerAdapter extends AbstractAdapter
+final class SymfonyMailerAdapter extends AbstractAdapter implements CcAwareAdapterInterface
 {
     private MailerInterface $mailer;
 
@@ -44,6 +45,40 @@ final class SymfonyMailerAdapter extends AbstractAdapter
         array $attachments = [],
         array $replyTo = [],
     ): void {
+        $this->sendMessage(
+            $renderedEmail, $senderAddress, $senderName, $recipients, $replyTo, $attachments, $email, $data
+        );
+    }
+
+    public function sendWithCC(
+        array $recipients,
+        string $senderAddress,
+        string $senderName,
+        RenderedEmail $renderedEmail,
+        EmailInterface $email,
+        array $data,
+        array $attachments = [],
+        array $replyTo = [],
+        array $ccRecipients = [],
+        array $bccRecipients = [],
+    ): void {
+        $this->sendMessage(
+            $renderedEmail, $senderAddress, $senderName, $recipients, $replyTo, $attachments, $email, $data, $ccRecipients, $bccRecipients
+        );
+    }
+
+    private function sendMessage(
+        RenderedEmail $renderedEmail,
+        string $senderAddress,
+        string $senderName,
+        array $recipients,
+        array $replyTo,
+        array $attachments,
+        EmailInterface $email,
+        array $data,
+        array $ccRecipients = [],
+        array $bccRecipients = [],
+    ): void {
         $message = (new Email())
             ->subject($renderedEmail->getSubject())
             ->from(new Address($senderAddress, $senderName))
@@ -51,6 +86,13 @@ final class SymfonyMailerAdapter extends AbstractAdapter
             ->replyTo(...$replyTo)
             ->html($renderedEmail->getBody())
         ;
+
+        if (!empty($ccRecipients)) {
+            $message->addCc(...$ccRecipients);
+        }
+        if (!empty($bccRecipients)) {
+            $message->addBcc(...$bccRecipients);
+        }
 
         foreach ($attachments as $attachment) {
             $message->attachFromPath($attachment);

--- a/src/Bundle/spec/Sender/Adapter/DefaultAdapterSpec.php
+++ b/src/Bundle/spec/Sender/Adapter/DefaultAdapterSpec.php
@@ -37,5 +37,13 @@ final class DefaultAdapterSpec extends ObjectBehavior
             )))
             ->during('send', [['pawel@sylius.com'], 'arnaud@sylius.com', 'arnaud', $renderedEmail, $email, []])
         ;
+
+        $this
+            ->shouldThrow(new \RuntimeException(sprintf(
+                'You need to configure an adapter to send the email. Take a look at %s (requires "symfony/mailer" library).',
+                SymfonyMailerAdapter::class
+            )))
+            ->during('sendWithCc', [['pawel@sylius.com'], 'arnaud@sylius.com', 'arnaud', $renderedEmail, $email, [], [], [], ['cc@example.com'], ['bcc@example.com']])
+        ;
     }
 }

--- a/src/Bundle/spec/Sender/Adapter/DefaultAdapterSpec.php
+++ b/src/Bundle/spec/Sender/Adapter/DefaultAdapterSpec.php
@@ -41,7 +41,7 @@ final class DefaultAdapterSpec extends ObjectBehavior
         $this
             ->shouldThrow(new \RuntimeException(sprintf(
                 'You need to configure an adapter to send the email. Take a look at %s (requires "symfony/mailer" library).',
-                SymfonyMailerAdapter::class
+                SymfonyMailerAdapter::class,
             )))
             ->during('sendWithCc', [['pawel@sylius.com'], 'arnaud@sylius.com', 'arnaud', $renderedEmail, $email, [], [], [], ['cc@example.com'], ['bcc@example.com']])
         ;

--- a/src/Bundle/spec/Sender/Adapter/SwiftMailerAdapterSpec.php
+++ b/src/Bundle/spec/Sender/Adapter/SwiftMailerAdapterSpec.php
@@ -50,7 +50,7 @@ final class SwiftMailerAdapterSpec extends ObjectBehavior
             ->shouldBeCalled()
         ;
 
-        $mailer->send(Argument::that(function(\Swift_Message $message): bool {
+        $mailer->send(Argument::that(function (\Swift_Message $message): bool {
             return
                 $message->getSubject() === 'subject' &&
                 $message->getBody() === 'body' &&
@@ -78,7 +78,7 @@ final class SwiftMailerAdapterSpec extends ObjectBehavior
         \Swift_Mailer $mailer,
         EmailInterface $email,
         EventDispatcherInterface $dispatcher,
-        RenderedEmail $renderedEmail
+        RenderedEmail $renderedEmail,
     ): void {
         $this->setEventDispatcher($dispatcher);
 
@@ -90,7 +90,7 @@ final class SwiftMailerAdapterSpec extends ObjectBehavior
             ->shouldBeCalled()
         ;
 
-        $mailer->send(Argument::that(function(\Swift_Message $message): bool {
+        $mailer->send(Argument::that(function (\Swift_Message $message): bool {
             return
                 $message->getSubject() === 'subject' &&
                 $message->getBody() === 'body' &&
@@ -116,7 +116,7 @@ final class SwiftMailerAdapterSpec extends ObjectBehavior
             [],
             [],
             ['cc@example.com'],
-            ['bcc@example.com']
+            ['bcc@example.com'],
         );
     }
 }

--- a/src/Bundle/spec/Sender/Adapter/SymfonyMailerAdapterSpec.php
+++ b/src/Bundle/spec/Sender/Adapter/SymfonyMailerAdapterSpec.php
@@ -54,7 +54,7 @@ final class SymfonyMailerAdapterSpec extends ObjectBehavior
             ->shouldBeCalled()
         ;
 
-        $mailer->send(Argument::that(function(Email $message): bool {
+        $mailer->send(Argument::that(function (Email $message): bool {
             return
                 $message->getSubject() === 'subject' &&
                 $message->getBody()->bodyToString() === 'body' &&
@@ -81,12 +81,12 @@ final class SymfonyMailerAdapterSpec extends ObjectBehavior
     function it_sends_an_email_with_cc_and_bcc(
         MailerInterface $mailer,
         EmailInterface $email,
-        RenderedEmail $renderedEmail
+        RenderedEmail $renderedEmail,
     ): void {
         $renderedEmail->getSubject()->willReturn('subject');
         $renderedEmail->getBody()->willReturn('body');
 
-        $mailer->send(Argument::that(function(Email $message): bool {
+        $mailer->send(Argument::that(function (Email $message): bool {
             return
                 $message->getSubject() === 'subject' &&
                 $message->getBody()->bodyToString() === 'body' &&
@@ -107,7 +107,7 @@ final class SymfonyMailerAdapterSpec extends ObjectBehavior
             [],
             [],
             ['cc@example.com'],
-            ['bcc@example.com']
+            ['bcc@example.com'],
         );
     }
 

--- a/src/Bundle/spec/Sender/Adapter/SymfonyMailerAdapterSpec.php
+++ b/src/Bundle/spec/Sender/Adapter/SymfonyMailerAdapterSpec.php
@@ -60,7 +60,7 @@ final class SymfonyMailerAdapterSpec extends ObjectBehavior
                 $message->getBody()->bodyToString() === 'body' &&
                 $message->getFrom()[0] == new Address('arnaud@sylius.com', 'arnaud') &&
                 $message->getTo()[0] == new Address('pawel@sylius.com')
-                ;
+            ;
         }))->shouldBeCalled();
 
         $dispatcher

--- a/src/Component/Sender/Adapter/AdapterInterface.php
+++ b/src/Component/Sender/Adapter/AdapterInterface.php
@@ -31,6 +31,6 @@ interface AdapterInterface
         EmailInterface $email,
         array $data,
         array $attachments = [],
-        array $replyTo = []
+        array $replyTo = [],
     ): void;
 }

--- a/src/Component/Sender/Adapter/AdapterInterface.php
+++ b/src/Component/Sender/Adapter/AdapterInterface.php
@@ -32,5 +32,7 @@ interface AdapterInterface
         array $data,
         array $attachments = [],
         array $replyTo = [],
+        array $ccRecipients = [],
+        array $bccRecipients = []
     ): void;
 }

--- a/src/Component/Sender/Adapter/CcAwareAdapterInterface.php
+++ b/src/Component/Sender/Adapter/CcAwareAdapterInterface.php
@@ -1,14 +1,5 @@
 <?php
 
-/*
- * This file is part of the Sylius package.
- *
- * (c) Paweł Jędrzejewski
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 declare(strict_types=1);
 
 namespace Sylius\Component\Mailer\Sender\Adapter;
@@ -16,14 +7,16 @@ namespace Sylius\Component\Mailer\Sender\Adapter;
 use Sylius\Component\Mailer\Model\EmailInterface;
 use Sylius\Component\Mailer\Renderer\RenderedEmail;
 
-interface AdapterInterface
+interface CcAwareAdapterInterface extends AdapterInterface
 {
     /**
      * @param string[] $recipients A list of email addresses to receive the message.
      * @param string[] $attachments A list of file paths to attach to the message.
      * @param string[] $replyTo A list of email addresses to set as the Reply-To address for the message.
+     * @param string[] $ccRecipients A list of email addresses set as carbon copy
+     * @param string[] $bccRecipients A list of email addresses set as blind carbon copy
      */
-    public function send(
+    public function sendWithCC(
         array $recipients,
         string $senderAddress,
         string $senderName,
@@ -31,6 +24,8 @@ interface AdapterInterface
         EmailInterface $email,
         array $data,
         array $attachments = [],
-        array $replyTo = []
+        array $replyTo = [],
+        array $ccRecipients = [],
+        array $bccRecipients = []
     ): void;
 }

--- a/src/Component/Sender/Adapter/CcAwareAdapterInterface.php
+++ b/src/Component/Sender/Adapter/CcAwareAdapterInterface.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\Component\Mailer\Sender\Adapter;
@@ -26,6 +35,6 @@ interface CcAwareAdapterInterface extends AdapterInterface
         array $attachments = [],
         array $replyTo = [],
         array $ccRecipients = [],
-        array $bccRecipients = []
+        array $bccRecipients = [],
     ): void;
 }

--- a/src/Component/Sender/Sender.php
+++ b/src/Component/Sender/Sender.php
@@ -44,8 +44,15 @@ final class Sender implements SenderInterface
     /**
      * {@inheritdoc}
      */
-    public function send(string $code, array $recipients, array $data = [], array $attachments = [], array $replyTo = []): void
-    {
+    public function send(
+        string $code,
+        array $recipients,
+        array $data = [],
+        array $attachments = [],
+        array $replyTo = [],
+        array $ccRecipients = [],
+        array $bccRecipients = []
+    ): void {
         Assert::allStringNotEmpty($recipients);
 
         $email = $this->provider->getEmail($code);
@@ -68,6 +75,8 @@ final class Sender implements SenderInterface
             $data,
             $attachments,
             $replyTo,
+            $ccRecipients,
+            $bccRecipients
         );
     }
 }

--- a/src/Component/Sender/SenderInterface.php
+++ b/src/Component/Sender/SenderInterface.php
@@ -19,8 +19,6 @@ interface SenderInterface
      * @param string[]|null[] $recipients A list of email addresses to receive the message. Providing null or empty string in the list of recipients is deprecated and will be removed in SyliusMailerBundle 2.0
      * @param string[] $attachments A list of file paths to attach to the message.
      * @param string[] $replyTo A list of email addresses to set as the Reply-To address for the message.
-     * @param string[] $ccRecipients A list of email addressed as carbon copy
-     * @param string[] $bccRecipients A list of email addressed as blind carbon copy
      */
     public function send(
         string $code,
@@ -28,7 +26,5 @@ interface SenderInterface
         array $data = [],
         array $attachments = [],
         array $replyTo = [],
-        array $ccRecipients = [],
-        array $bccRecipients = []
     ): void;
 }

--- a/src/Component/Sender/SenderInterface.php
+++ b/src/Component/Sender/SenderInterface.php
@@ -19,6 +19,16 @@ interface SenderInterface
      * @param string[]|null[] $recipients A list of email addresses to receive the message. Providing null or empty string in the list of recipients is deprecated and will be removed in SyliusMailerBundle 2.0
      * @param string[] $attachments A list of file paths to attach to the message.
      * @param string[] $replyTo A list of email addresses to set as the Reply-To address for the message.
+     * @param string[] $ccRecipients A list of email addressed as carbon copy
+     * @param string[] $bccRecipients A list of email addressed as blind carbon copy
      */
-    public function send(string $code, array $recipients, array $data = [], array $attachments = [], array $replyTo = []): void;
+    public function send(
+        string $code,
+        array $recipients,
+        array $data = [],
+        array $attachments = [],
+        array $replyTo = [],
+        array $ccRecipients = [],
+        array $bccRecipients = []
+    ): void;
 }

--- a/src/Component/Sender/SenderInterface.php
+++ b/src/Component/Sender/SenderInterface.php
@@ -16,9 +16,13 @@ namespace Sylius\Component\Mailer\Sender;
 interface SenderInterface
 {
     /**
+     * @deprecated using this method without 2 last arguments ($ccRecipients and $bccRecipients) is deprecated since 1.8 and won't be possible since 2.0
+     *
      * @param string[]|null[] $recipients A list of email addresses to receive the message. Providing null or empty string in the list of recipients is deprecated and will be removed in SyliusMailerBundle 2.0
      * @param string[] $attachments A list of file paths to attach to the message.
      * @param string[] $replyTo A list of email addresses to set as the Reply-To address for the message.
+     * @param string[] $ccRecipients A list of email addresses set as carbon copy
+     * @param string[] $bccRecipients A list of email addresses set as blind carbon copy
      */
     public function send(
         string $code,

--- a/src/Component/spec/Sender/SenderSpec.php
+++ b/src/Component/spec/Sender/SenderSpec.php
@@ -48,9 +48,20 @@ final class SenderSpec extends ObjectBehavior
         $data = ['foo' => 2];
 
         $rendererAdapter->render($email, ['foo' => 2])->willReturn($renderedEmail);
-        $senderAdapter->send(['john@example.com'], 'sender@example.com', 'Sender', $renderedEmail, $email, $data, [], [])->shouldBeCalled();
+        $senderAdapter->send(
+            ['john@example.com'],
+            'sender@example.com',
+            'Sender',
+            $renderedEmail,
+            $email,
+            $data,
+            [],
+            [],
+            ['cc@mail.com'],
+            ['bcc@mail.com']
+        )->shouldBeCalled();
 
-        $this->send('bar', ['john@example.com'], $data, []);
+        $this->send('bar', ['john@example.com'], $data, [], [], ['cc@mail.com'], ['bcc@mail.com']);
     }
 
     function it_does_not_send_disabled_emails(

--- a/src/Component/spec/Sender/SenderSpec.php
+++ b/src/Component/spec/Sender/SenderSpec.php
@@ -20,7 +20,7 @@ use Sylius\Component\Mailer\Provider\DefaultSettingsProviderInterface;
 use Sylius\Component\Mailer\Provider\EmailProviderInterface;
 use Sylius\Component\Mailer\Renderer\Adapter\AdapterInterface as RendererAdapterInterface;
 use Sylius\Component\Mailer\Renderer\RenderedEmail;
-use Sylius\Component\Mailer\Sender\Adapter\AdapterInterface as SenderAdapterInterface;
+use Sylius\Component\Mailer\Sender\Adapter\CcAwareAdapterInterface as SenderAdapterInterface;
 
 final class SenderSpec extends ObjectBehavior
 {
@@ -57,11 +57,40 @@ final class SenderSpec extends ObjectBehavior
             $data,
             [],
             [],
-            ['cc@mail.com'],
-            ['bcc@mail.com']
         )->shouldBeCalled();
 
-        $this->send('bar', ['john@example.com'], $data, [], [], ['cc@mail.com'], ['bcc@mail.com']);
+        $this->send('bar', ['john@example.com'], $data, [], []);
+    }
+
+    function it_sends_an_email_with_cc_and_bcc_through_the_adapter(
+        EmailInterface $email,
+        EmailProviderInterface $provider,
+        RenderedEmail $renderedEmail,
+        RendererAdapterInterface $rendererAdapter,
+        SenderAdapterInterface $senderAdapter,
+    ): void {
+        $provider->getEmail('bar')->willReturn($email);
+        $email->isEnabled()->willReturn(true);
+        $email->getSenderAddress()->willReturn('sender@example.com');
+        $email->getSenderName()->willReturn('Sender');
+
+        $data = ['foo' => 2];
+
+        $rendererAdapter->render($email, ['foo' => 2])->willReturn($renderedEmail);
+        $senderAdapter->sendWithCC(
+            ['john@example.com'],
+            'sender@example.com',
+            'Sender',
+            $renderedEmail,
+            $email,
+            $data,
+            [],
+            [],
+            ['cc@example.com'],
+            ['bcc@example.com'],
+        )->shouldBeCalled();
+
+        $this->send('bar', ['john@example.com'], $data, [], [], ['cc@example.com'], ['bcc@example.com']);
     }
 
     function it_does_not_send_disabled_emails(


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | replaces #11 
| License         | MIT

This PR is based on #11, fixed, rebased and improved 🖖 My biggest concern is a `Sender` - I wanted to avoid adding another interface (as I did with `AdapterInterface`), so I made some [shenanigans with arguments counting](https://github.com/Sylius/SyliusMailerBundle/compare/master...Zales0123:allow-to-specify-cc-and-bcc-in-sender?expand=1#diff-00a547ed6f279be9cf3256dbf78abde52de2d0a243f179dde0818f9e324017c3R70-R86)... but I'm not convinced it's the best choice 🤷‍♂️ Still, BC breaks-free for sure.

It would be great to merge it before 1.8 release 🚀 