### PR TITLE
Remove dead code on sender adapters

### DIFF
--- a/src/Bundle/Sender/Adapter/DefaultAdapter.php
+++ b/src/Bundle/Sender/Adapter/DefaultAdapter.php
@@ -20,9 +20,6 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 final class DefaultAdapter extends AbstractAdapter
 {
-    /** @var EventDispatcherInterface|null */
-    protected $dispatcher;
-
     public function __construct(?EventDispatcherInterface $dispatcher = null)
     {
         $this->dispatcher = $dispatcher;

--- a/src/Bundle/Sender/Adapter/SwiftMailerAdapter.php
+++ b/src/Bundle/Sender/Adapter/SwiftMailerAdapter.php
@@ -29,9 +29,6 @@ class SwiftMailerAdapter extends AbstractAdapter implements CcAwareAdapterInterf
     /** @var \Swift_Mailer */
     protected $mailer;
 
-    /** @var EventDispatcherInterface|null */
-    protected $dispatcher;
-
     public function __construct(\Swift_Mailer $mailer, ?EventDispatcherInterface $dispatcher = null)
     {
         trigger_deprecation(


### PR DESCRIPTION
TL;DR: cleaning useless code, improve maintainability

The dispatcher is already present in the parent class as a protected argument. (having it in every class is dead code to maintain with comment for covariance that phpstan & psalm may highlight etc)

| Q               | A
| --------------- | -----
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | none
| License         | MIT

Just some free code cleaning.