### PR TITLE
Email modification after creation

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -42,5 +42,11 @@
                 <file name="src/Bundle/Sender/Adapter/DefaultAdapter.php" />
             </errorLevel>
         </NonInvariantDocblockPropertyType>
+
+        <InvalidArgument>
+            <errorLevel type="suppress">
+                <file name="src/Bundle/Sender/Adapter/SymfonyMailerAdapter.php" />
+            </errorLevel>
+        </InvalidArgument>
     </issueHandlers>
 </psalm>

--- a/src/Bundle/Resources/config/services.xml
+++ b/src/Bundle/Resources/config/services.xml
@@ -29,6 +29,7 @@
             <argument type="service" id="sylius.email_sender.adapter" />
             <argument type="service" id="sylius.email_provider" />
             <argument type="service" id="sylius.mailer.default_settings_provider" />
+            <argument type="service" id="Sylius\Component\Mailer\Modifier\EmailModifierInterface" />
         </service>
         <service id="Sylius\Component\Mailer\Sender\SenderInterface" alias="sylius.email_sender" />
 
@@ -77,6 +78,13 @@
             public="true"
         >
             <argument type="service" id="mailer.mailer" />
+        </service>
+
+        <service
+            id="Sylius\Component\Mailer\Modifier\EmailModifierInterface"
+            class="Sylius\Component\Mailer\Modifier\CompositeEmailModifier"
+        >
+            <argument type="tagged" tag="sylius_mailer.email_modifier" />
         </service>
     </services>
 </container>

--- a/src/Bundle/test/config/packages/test/sylius_mailer.yaml
+++ b/src/Bundle/test/config/packages/test/sylius_mailer.yaml
@@ -1,7 +1,12 @@
 sylius_mailer:
+    sender:
+        name: Sender
+        address: sender@example.com
     sender_adapter: sylius.email_sender.adapter.symfony_mailer
     emails:
         test_email:
             template: 'Email/test.html.twig'
         test_email_with_data:
             template: 'Email/testWithData.html.twig'
+        test_modified_email:
+            template: 'Email/test.html.twig'

--- a/src/Bundle/test/config/services.yaml
+++ b/src/Bundle/test/config/services.yaml
@@ -1,3 +1,7 @@
 parameters:
     locale: en_US
     secret: "Three can keep a secret, if two of them are dead."
+
+services:
+    App\Modifier\EmailSenderNameModifier:
+        tags: ['sylius_mailer.email_modifier']

--- a/src/Bundle/test/src/Modifier/EmailSenderNameModifier.php
+++ b/src/Bundle/test/src/Modifier/EmailSenderNameModifier.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace App\Modifier;

--- a/src/Bundle/test/src/Modifier/EmailSenderNameModifier.php
+++ b/src/Bundle/test/src/Modifier/EmailSenderNameModifier.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Modifier;
+
+use Sylius\Component\Mailer\Model\EmailInterface;
+use Sylius\Component\Mailer\Modifier\EmailModifierInterface;
+
+final class EmailSenderNameModifier implements EmailModifierInterface
+{
+    public function modify(EmailInterface $email, array $factors = []): EmailInterface
+    {
+        if ($email->getCode() === 'test_modified_email') {
+            $email->setSenderName('Modified sender name');
+        }
+
+        return $email;
+    }
+}

--- a/src/Bundle/tests/Functional/SymfonyMailerSenderTest.php
+++ b/src/Bundle/tests/Functional/SymfonyMailerSenderTest.php
@@ -45,7 +45,7 @@ final class SymfonyMailerSenderTest extends KernelTestCase
         $this->assertEmailHtmlBodyContains($email, 'Test email body');
         $this->assertEmailHasHeader($email, 'subject', 'Test email subject');
         $this->assertEmailHasSenderName($email, 'Sender');
-        $this->assertEmailHasSenderEmail($email, 'sender@example.com');
+        $this->assertEmailAddressContains($email, 'From', 'sender@example.com');
     }
 
     /** @test */
@@ -59,7 +59,7 @@ final class SymfonyMailerSenderTest extends KernelTestCase
         $this->assertEmailHtmlBodyContains($email, 'Test email body. Data: Test data.');
         $this->assertEmailHasHeader($email, 'subject', 'Test email with data subject');
         $this->assertEmailHasSenderName($email, 'Sender');
-        $this->assertEmailHasSenderEmail($email, 'sender@example.com');
+        $this->assertEmailAddressContains($email, 'From', 'sender@example.com');
     }
 
     /** @test */
@@ -90,7 +90,7 @@ final class SymfonyMailerSenderTest extends KernelTestCase
         $this->assertEmailHtmlBodyContains($email, 'Test email body');
         $this->assertEmailHasHeader($email, 'subject', 'Test email subject');
         $this->assertEmailHasSenderName($email, 'Modified sender name');
-        $this->assertEmailHasSenderEmail($email, 'sender@example.com');
+        $this->assertEmailAddressContains($email, 'From', 'sender@example.com');
     }
 
     private function assertEmailHasSenderName(?RawMessage $email, string $sender): void
@@ -103,17 +103,5 @@ final class SymfonyMailerSenderTest extends KernelTestCase
         }
 
         throw new ExpectationFailedException(sprintf('There is no email sent by sender with name "%s"', $sender));
-    }
-
-    private function assertEmailHasSenderEmail(?RawMessage $email, string $emailAddress): void
-    {
-        /** @var Address $address */
-        foreach ($email->getHeaders()->get('from')->getAddresses() as $address) {
-            if ($address->getAddress() === $emailAddress) {
-                return;
-            }
-        }
-
-        throw new ExpectationFailedException(sprintf('There is no email sent by sender with email "%s"', $emailAddress));
     }
 }

--- a/src/Bundle/tests/Functional/SymfonyMailerSenderTest.php
+++ b/src/Bundle/tests/Functional/SymfonyMailerSenderTest.php
@@ -13,9 +13,12 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\MailerBundle\tests\Functional;
 
+use PHPUnit\Framework\ExpectationFailedException;
 use Sylius\Component\Mailer\Sender\SenderInterface;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Bundle\FrameworkBundle\Test\MailerAssertionsTrait;
+use Symfony\Component\Mime\Address;
+use Symfony\Component\Mime\RawMessage;
 
 final class SymfonyMailerSenderTest extends KernelTestCase
 {
@@ -25,7 +28,7 @@ final class SymfonyMailerSenderTest extends KernelTestCase
 
     protected function setUp(): void
     {
-        self::bootKernel(['environment' => 'test_with_symfony_mailer']);
+        self::bootKernel(['environment' => 'test']);
         $container = self::getContainer();
 
         $this->sender = $container->get('sylius.email_sender');
@@ -41,6 +44,8 @@ final class SymfonyMailerSenderTest extends KernelTestCase
         $email = $this->getMailerMessage();
         $this->assertEmailHtmlBodyContains($email, 'Test email body');
         $this->assertEmailHasHeader($email, 'subject', 'Test email subject');
+        $this->assertEmailHasSenderName($email, 'Sender');
+        $this->assertEmailHasSenderEmail($email, 'sender@example.com');
     }
 
     /** @test */
@@ -53,6 +58,8 @@ final class SymfonyMailerSenderTest extends KernelTestCase
         $email = $this->getMailerMessage();
         $this->assertEmailHtmlBodyContains($email, 'Test email body. Data: Test data.');
         $this->assertEmailHasHeader($email, 'subject', 'Test email with data subject');
+        $this->assertEmailHasSenderName($email, 'Sender');
+        $this->assertEmailHasSenderEmail($email, 'sender@example.com');
     }
 
     /** @test */
@@ -70,5 +77,43 @@ final class SymfonyMailerSenderTest extends KernelTestCase
         $this->assertEmailHasHeader($firstEmail, 'subject', 'Test email subject');
         $this->assertEmailHtmlBodyContains($secondEmail, 'Test email body. Data: Test data.');
         $this->assertEmailHasHeader($secondEmail, 'subject', 'Test email with data subject');
+    }
+
+    /** @test */
+    public function it_sends_conditionally_modified_email(): void
+    {
+        $this->sender->send('test_modified_email', ['test@example.com']);
+
+        $this->assertEmailCount(1);
+
+        $email = $this->getMailerMessage();
+        $this->assertEmailHtmlBodyContains($email, 'Test email body');
+        $this->assertEmailHasHeader($email, 'subject', 'Test email subject');
+        $this->assertEmailHasSenderName($email, 'Modified sender name');
+        $this->assertEmailHasSenderEmail($email, 'sender@example.com');
+    }
+
+    private function assertEmailHasSenderName(?RawMessage $email, string $sender): void
+    {
+        /** @var Address $address */
+        foreach ($email->getHeaders()->get('from')->getAddresses() as $address) {
+            if ($address->getName() === $sender) {
+                return;
+            }
+        }
+
+        throw new ExpectationFailedException(sprintf('There is no email sent by sender with name "%s"', $sender));
+    }
+
+    private function assertEmailHasSenderEmail(?RawMessage $email, string $emailAddress): void
+    {
+        /** @var Address $address */
+        foreach ($email->getHeaders()->get('from')->getAddresses() as $address) {
+            if ($address->getAddress() === $emailAddress) {
+                return;
+            }
+        }
+
+        throw new ExpectationFailedException(sprintf('There is no email sent by sender with email "%s"', $emailAddress));
     }
 }

--- a/src/Component/Modifier/CompositeEmailModifier.php
+++ b/src/Component/Modifier/CompositeEmailModifier.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Mailer\Modifier;
+
+use Sylius\Component\Mailer\Model\EmailInterface;
+
+final class CompositeEmailModifier implements EmailModifierInterface
+{
+    /**
+     * @param EmailModifierInterface[] $emailModifiers
+     */
+    public function __construct(
+        private array $emailModifiers = []
+    ) {
+    }
+
+    public function modify(EmailInterface $email, array $factors = []): EmailInterface
+    {
+        foreach ($this->emailModifiers as $modifier) {
+            $email = $modifier->modify($email, $factors);
+        }
+
+        return $email;
+    }
+}

--- a/src/Component/Modifier/CompositeEmailModifier.php
+++ b/src/Component/Modifier/CompositeEmailModifier.php
@@ -12,7 +12,7 @@ final class CompositeEmailModifier implements EmailModifierInterface
      * @param EmailModifierInterface[] $emailModifiers
      */
     public function __construct(
-        private array $emailModifiers = []
+        private iterable $emailModifiers = []
     ) {
     }
 

--- a/src/Component/Modifier/CompositeEmailModifier.php
+++ b/src/Component/Modifier/CompositeEmailModifier.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\Component\Mailer\Modifier;
@@ -12,7 +21,7 @@ final class CompositeEmailModifier implements EmailModifierInterface
      * @param EmailModifierInterface[] $emailModifiers
      */
     public function __construct(
-        private iterable $emailModifiers = []
+        private iterable $emailModifiers = [],
     ) {
     }
 

--- a/src/Component/Modifier/EmailModifierInterface.php
+++ b/src/Component/Modifier/EmailModifierInterface.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\Component\Mailer\Modifier;

--- a/src/Component/Modifier/EmailModifierInterface.php
+++ b/src/Component/Modifier/EmailModifierInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Mailer\Modifier;
+
+use Sylius\Component\Mailer\Model\EmailInterface;
+
+interface EmailModifierInterface
+{
+    public function modify(EmailInterface $email, array $factors = []): EmailInterface;
+}

--- a/src/Component/Sender/Sender.php
+++ b/src/Component/Sender/Sender.php
@@ -31,9 +31,7 @@ final class Sender implements SenderInterface
         private ?EmailModifierInterface $emailModifier = null,
     ) {
         if ($this->emailModifier === null) {
-            trigger_deprecation(
-                'sylius/mailer-bundle',
-                '2.0',
+            @trigger_error(
                 'Not passing EmailModifierInterface is deprecated since 2.1 and will not be possible in 3.0',
             );
         }

--- a/src/Component/Sender/Sender.php
+++ b/src/Component/Sender/Sender.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Component\Mailer\Sender;
 
+use Sylius\Component\Mailer\Modifier\EmailModifierInterface;
 use Sylius\Component\Mailer\Provider\DefaultSettingsProviderInterface;
 use Sylius\Component\Mailer\Provider\EmailProviderInterface;
 use Sylius\Component\Mailer\Renderer\Adapter\AdapterInterface as RendererAdapterInterface;
@@ -27,7 +28,15 @@ final class Sender implements SenderInterface
         private SenderAdapterInterface $senderAdapter,
         private EmailProviderInterface $provider,
         private DefaultSettingsProviderInterface $defaultSettingsProvider,
+        private ?EmailModifierInterface $emailModifier = null,
     ) {
+        if ($this->emailModifier === null) {
+            trigger_deprecation(
+                'sylius/mailer-bundle',
+                '2.0',
+                'Not passing EmailModifierInterface is deprecated since 2.1 and will not be possible in 3.0',
+            );
+        }
     }
 
     /**
@@ -45,6 +54,9 @@ final class Sender implements SenderInterface
         Assert::allStringNotEmpty($recipients);
 
         $email = $this->provider->getEmail($code);
+        if ($this->emailModifier !== null) {
+            $email = $this->emailModifier->modify($email);
+        }
 
         if (!$email->isEnabled()) {
             return;

--- a/src/Component/Sender/Sender.php
+++ b/src/Component/Sender/Sender.php
@@ -53,7 +53,7 @@ final class Sender implements SenderInterface
 
         $email = $this->provider->getEmail($code);
         if ($this->emailModifier !== null) {
-            $email = $this->emailModifier->modify($email);
+            $email = $this->emailModifier->modify($email, $data);
         }
 
         if (!$email->isEnabled()) {

--- a/src/Component/spec/Modifier/CompositeEmailModifierSpec.php
+++ b/src/Component/spec/Modifier/CompositeEmailModifierSpec.php
@@ -1,12 +1,20 @@
 <?php
 
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace spec\Sylius\Component\Mailer\Modifier;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Mailer\Model\EmailInterface;
-use Sylius\Component\Mailer\Modifier\CompositeEmailModifier;
 use Sylius\Component\Mailer\Modifier\EmailModifierInterface;
 
 final class CompositeEmailModifierSpec extends ObjectBehavior
@@ -24,7 +32,7 @@ final class CompositeEmailModifierSpec extends ObjectBehavior
     function it_uses_all_email_modifiers_to_modify_the_email(
         EmailModifierInterface $firstEmailModifier,
         EmailModifierInterface $secondEmailModifier,
-        EmailInterface $email
+        EmailInterface $email,
     ) {
         $firstEmailModifier->modify($email, ['factor' => 'value'])->shouldBeCalled()->willReturn($email);
         $secondEmailModifier->modify($email, ['factor' => 'value'])->shouldBeCalled()->willReturn($email);

--- a/src/Component/spec/Modifier/CompositeEmailModifierSpec.php
+++ b/src/Component/spec/Modifier/CompositeEmailModifierSpec.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Sylius\Component\Mailer\Modifier;
+
+use PhpSpec\ObjectBehavior;
+use Sylius\Component\Mailer\Model\EmailInterface;
+use Sylius\Component\Mailer\Modifier\CompositeEmailModifier;
+use Sylius\Component\Mailer\Modifier\EmailModifierInterface;
+
+final class CompositeEmailModifierSpec extends ObjectBehavior
+{
+    function let(EmailModifierInterface $firstEmailModifier, EmailModifierInterface $secondEmailModifier): void
+    {
+        $this->beConstructedWith([$firstEmailModifier, $secondEmailModifier]);
+    }
+
+    function it_implements_email_modifier_interface(): void
+    {
+        $this->shouldImplement(EmailModifierInterface::class);
+    }
+
+    function it_uses_all_email_modifiers_to_modify_the_email(
+        EmailModifierInterface $firstEmailModifier,
+        EmailModifierInterface $secondEmailModifier,
+        EmailInterface $email
+    ) {
+        $firstEmailModifier->modify($email, ['factor' => 'value'])->shouldBeCalled()->willReturn($email);
+        $secondEmailModifier->modify($email, ['factor' => 'value'])->shouldBeCalled()->willReturn($email);
+
+        $this->modify($email, ['factor' => 'value'])->shouldReturn($email);
+    }
+}

--- a/src/Component/spec/Sender/SenderSpec.php
+++ b/src/Component/spec/Sender/SenderSpec.php
@@ -107,13 +107,13 @@ final class SenderSpec extends ObjectBehavior
 
         $provider->getEmail('bar')->willReturn($email);
 
-        $emailModifier->modify($email)->shouldBeCalled()->willReturn($email);
+        $data = ['foo' => 2];
+
+        $emailModifier->modify($email, $data)->shouldBeCalled()->willReturn($email);
 
         $email->isEnabled()->willReturn(true);
         $email->getSenderAddress()->willReturn('sender@example.com');
         $email->getSenderName()->willReturn('Modified sender');
-
-        $data = ['foo' => 2];
 
         $rendererAdapter->render($email, ['foo' => 2])->willReturn($renderedEmail);
         $senderAdapter->sendWithCC(


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | it probably need [this](https://github.com/Sylius/SyliusMailerBundle/pull/184) to be merged before for the green build
| License         | MIT

While the default configuration-based email creation is sufficient in most cases, it's not uncommon for one to need it conditional or dynamic in any other way. I thought about modifying the `EmailProvider::getEmail(string $code)` method to accept the `array $data` argument, but thought it would be more extendible to provide a set of _modifiers_ services, that could be easily implemented in the application. Maybe it should also contain the `support(EmailInterface $email): bool` method, to not force checking the email code inside the `modify` method 🤔 

Let me know what you think about such a feature 🖖 I will add some documentation to this feature if we would like to proceed with it 🫡 