### PR TITLE
Debug Sylius Mailer command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,8 @@
         "symfony/framework-bundle": "^5.4 || ^6.0",
         "symfony/http-kernel": "^5.4 || ^6.0",
         "twig/twig": "^2.12 || ^3.3",
-        "webmozart/assert": "^1.9"
+        "webmozart/assert": "^1.9",
+        "symfony/translation": "^5.4 || ^6.0"
     },
     "replace": {
         "sylius/mailer": "self.version"

--- a/src/Bundle/Cli/DebugMailerCommand.php
+++ b/src/Bundle/Cli/DebugMailerCommand.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\Bundle\MailerBundle\Command;
+namespace Sylius\Bundle\MailerBundle\Cli;
 
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;

--- a/src/Bundle/Cli/DebugMailerCommand.php
+++ b/src/Bundle/Cli/DebugMailerCommand.php
@@ -12,6 +12,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Contracts\Translation\TranslatorInterface;
+use Twig\Loader\LoaderInterface;
 
 #[AsCommand(name: 'sylius:debug:mailer', description: 'Shows configured emails and sender data')]
 final class DebugMailerCommand extends Command
@@ -20,8 +21,8 @@ final class DebugMailerCommand extends Command
         private string $senderName,
         private string $senderEmail,
         private array $emails,
-        private string $templatesDir,
         private TranslatorInterface $translator,
+        private LoaderInterface $templateLoader,
     ) {
         parent::__construct();
     }
@@ -87,6 +88,6 @@ final class DebugMailerCommand extends Command
         $io->writeln(sprintf('<comment>Subject:</comment> %s', $this->translator->trans($email['subject'] ?? '')));
         $io->writeln(sprintf('<comment>Enabled:</comment> %s', $email['enabled'] ? '<info>yes</info>' : '<error>no</error>'));
         $io->newLine();
-        $io->text(file_get_contents($this->templatesDir.'/'.$email['template']));
+        $io->text($this->templateLoader->getSourceContext($email['template'])->getCode());
     }
 }

--- a/src/Bundle/Cli/DebugMailerCommand.php
+++ b/src/Bundle/Cli/DebugMailerCommand.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\Bundle\MailerBundle\Cli;

--- a/src/Bundle/Cli/Dumper/DumperInterface.php
+++ b/src/Bundle/Cli/Dumper/DumperInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\MailerBundle\Cli\Dumper;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+interface DumperInterface
+{
+    public function dump(InputInterface $input, OutputInterface $output, array $data = []): void;
+}

--- a/src/Bundle/Cli/Dumper/DumperInterface.php
+++ b/src/Bundle/Cli/Dumper/DumperInterface.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\Bundle\MailerBundle\Cli\Dumper;

--- a/src/Bundle/Cli/Dumper/EmailDetailsDumper.php
+++ b/src/Bundle/Cli/Dumper/EmailDetailsDumper.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\Bundle\MailerBundle\Cli\Dumper;

--- a/src/Bundle/Cli/Dumper/EmailDetailsDumper.php
+++ b/src/Bundle/Cli/Dumper/EmailDetailsDumper.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\MailerBundle\Cli\Dumper;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Contracts\Translation\TranslatorInterface;
+use Twig\Loader\LoaderInterface;
+use Webmozart\Assert\Assert;
+
+final class EmailDetailsDumper implements DumperInterface
+{
+    public function __construct(
+        private array $emails,
+        private TranslatorInterface $translator,
+        private LoaderInterface $templateLoader,
+    ) {
+    }
+
+    public function dump(InputInterface $input, OutputInterface $output, array $data = []): void
+    {
+        Assert::keyExists($data, 'code');
+
+        $code = $data['code'];
+        $email = $this->emails[$code];
+
+        $io = new SymfonyStyle($input, $output);
+        $io->title(sprintf('<fg=cyan>Email:</> %s', $code));
+        $io->writeln(sprintf('<comment>Subject:</comment> %s', $this->translator->trans($email['subject'] ?? '')));
+        $io->writeln(sprintf('<comment>Enabled:</comment> %s', $email['enabled'] ? '<info>yes</info>' : '<error>no</error>'));
+        $io->newLine();
+        $io->text($this->templateLoader->getSourceContext($email['template'])->getCode());
+    }
+}

--- a/src/Bundle/Cli/Dumper/EmailsListDumper.php
+++ b/src/Bundle/Cli/Dumper/EmailsListDumper.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\MailerBundle\Cli\Dumper;
+
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final class EmailsListDumper implements DumperInterface
+{
+    public function __construct(
+        private array $emails,
+        private TranslatorInterface $translator,
+    ) {
+    }
+
+    public function dump(InputInterface $input, OutputInterface $output, array $data = []): void
+    {
+        $io = new SymfonyStyle($input, $output);
+        $rows = [];
+
+        foreach ($this->emails as $code => $emailConfiguration) {
+            $rows[] = [
+                $code,
+                $emailConfiguration['template'],
+                $emailConfiguration['enabled'] ? 'yes' : 'no',
+                isset($emailConfiguration['subject']) ? $this->translator->trans($emailConfiguration['subject']) : '',
+            ];
+        }
+
+        $io->section('<info>Emails</info>');
+
+        $table = new Table($output);
+        $table->setHeaders(['Code', 'Template', 'Enabled', 'Subject']);
+        $table->setRows($rows);
+        $table->render();
+    }
+}

--- a/src/Bundle/Cli/Dumper/EmailsListDumper.php
+++ b/src/Bundle/Cli/Dumper/EmailsListDumper.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\Bundle\MailerBundle\Cli\Dumper;

--- a/src/Bundle/Cli/Dumper/SenderDataDumper.php
+++ b/src/Bundle/Cli/Dumper/SenderDataDumper.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\Bundle\MailerBundle\Cli\Dumper;

--- a/src/Bundle/Cli/Dumper/SenderDataDumper.php
+++ b/src/Bundle/Cli/Dumper/SenderDataDumper.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\MailerBundle\Cli\Dumper;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+final class SenderDataDumper implements DumperInterface
+{
+    public function __construct(
+        private string $senderName,
+        private string $senderEmail,
+    ) {
+    }
+
+    public function dump(InputInterface $input, OutputInterface $output, array $data = []): void
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $io->section('<info>Sender</info>');
+        $io->horizontalTable(['Name', 'Email'], [[$this->senderName, $this->senderEmail]]);
+    }
+}

--- a/src/Bundle/Command/DebugMailerCommand.php
+++ b/src/Bundle/Command/DebugMailerCommand.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\MailerBundle\Command;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+#[AsCommand(name: 'sylius:debug:mailer', description: 'Shows configured emails and sender data')]
+final class DebugMailerCommand extends Command
+{
+    public function __construct(
+        private string $senderName,
+        private string $senderEmail,
+        private array $emails,
+        private string $templatesDir,
+        private TranslatorInterface $translator,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addArgument('email', InputArgument::OPTIONAL, 'Email to be shown');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        if ($input->getArgument('email') === null) {
+            $this->dumpSenderData($input, $output);
+            $this->dumpListOfEmails($input, $output);
+
+            return 0;
+        }
+
+        /** @var string $email */
+        $email = $input->getArgument('email');
+
+        $this->dumpEmailDetails($input, $output, $email);
+
+        return 0;
+    }
+
+    private function dumpSenderData(InputInterface $input, OutputInterface $output): void
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $io->section('<info>Sender</info>');
+        $io->horizontalTable(['Name', 'Email'], [[$this->senderName, $this->senderEmail]]);
+    }
+
+    private function dumpListOfEmails(InputInterface $input, OutputInterface $output): void
+    {
+        $io = new SymfonyStyle($input, $output);
+        $rows = [];
+
+        foreach ($this->emails as $code => $emailConfiguration) {
+            $rows[] = [
+                $code,
+                $emailConfiguration['template'],
+                $emailConfiguration['enabled'] ? 'yes' : 'no',
+                isset($emailConfiguration['subject']) ? $this->translator->trans($emailConfiguration['subject']) : '',
+            ];
+        }
+
+        $io->section('<info>Emails</info>');
+
+        $table = new Table($output);
+        $table->setHeaders(['Code', 'Template', 'Enabled', 'Subject']);
+        $table->setRows($rows);
+        $table->render();
+    }
+
+    private function dumpEmailDetails(InputInterface $input, OutputInterface $output, string $code): void
+    {
+        $email = $this->emails[$code];
+
+        $io = new SymfonyStyle($input, $output);
+        $io->title(sprintf('<fg=cyan>Email:</> %s', $code));
+        $io->writeln(sprintf('<comment>Subject:</comment> %s', $this->translator->trans($email['subject'] ?? '')));
+        $io->writeln(sprintf('<comment>Enabled:</comment> %s', $email['enabled'] ? '<info>yes</info>' : '<error>no</error>'));
+        $io->newLine();
+        $io->text(file_get_contents($this->templatesDir.'/'.$email['template']));
+    }
+}

--- a/src/Bundle/Resources/config/services.xml
+++ b/src/Bundle/Resources/config/services.xml
@@ -86,5 +86,13 @@
         >
             <argument type="tagged" tag="sylius_mailer.email_modifier" />
         </service>
+
+        <service id="Sylius\Bundle\MailerBundle\Command\DebugMailerCommand" autoconfigure="true">
+            <argument>%sylius.mailer.sender_name%</argument>
+            <argument>%sylius.mailer.sender_address%</argument>
+            <argument>%sylius.mailer.emails%</argument>
+            <argument>%kernel.project_dir%/templates</argument>
+            <argument type="service" id="Symfony\Contracts\Translation\TranslatorInterface" />
+        </service>
     </services>
 </container>

--- a/src/Bundle/Resources/config/services.xml
+++ b/src/Bundle/Resources/config/services.xml
@@ -87,12 +87,26 @@
             <argument type="tagged" tag="sylius_mailer.email_modifier" />
         </service>
 
-        <service id="Sylius\Bundle\MailerBundle\Cli\DebugMailerCommand" autoconfigure="true">
-            <argument>%sylius.mailer.sender_name%</argument>
-            <argument>%sylius.mailer.sender_address%</argument>
+        <service id="Sylius\Bundle\MailerBundle\Cli\Dumper\EmailDetailsDumper">
             <argument>%sylius.mailer.emails%</argument>
             <argument type="service" id="Symfony\Contracts\Translation\TranslatorInterface" />
             <argument type="service" id="twig.loader" />
+        </service>
+
+        <service id="Sylius\Bundle\MailerBundle\Cli\Dumper\EmailsListDumper">
+            <argument>%sylius.mailer.emails%</argument>
+            <argument type="service" id="Symfony\Contracts\Translation\TranslatorInterface" />
+        </service>
+
+        <service id="Sylius\Bundle\MailerBundle\Cli\Dumper\SenderDataDumper">
+            <argument>%sylius.mailer.sender_name%</argument>
+            <argument>%sylius.mailer.sender_address%</argument>
+        </service>
+
+        <service id="Sylius\Bundle\MailerBundle\Cli\DebugMailerCommand" autoconfigure="true">
+            <argument type="service" id="Sylius\Bundle\MailerBundle\Cli\Dumper\SenderDataDumper" />
+            <argument type="service" id="Sylius\Bundle\MailerBundle\Cli\Dumper\EmailsListDumper" />
+            <argument type="service" id="Sylius\Bundle\MailerBundle\Cli\Dumper\EmailDetailsDumper" />
         </service>
     </services>
 </container>

--- a/src/Bundle/Resources/config/services.xml
+++ b/src/Bundle/Resources/config/services.xml
@@ -91,8 +91,8 @@
             <argument>%sylius.mailer.sender_name%</argument>
             <argument>%sylius.mailer.sender_address%</argument>
             <argument>%sylius.mailer.emails%</argument>
-            <argument>%kernel.project_dir%/templates</argument>
             <argument type="service" id="Symfony\Contracts\Translation\TranslatorInterface" />
+            <argument type="service" id="twig.loader" />
         </service>
     </services>
 </container>

--- a/src/Bundle/Resources/config/services.xml
+++ b/src/Bundle/Resources/config/services.xml
@@ -87,7 +87,7 @@
             <argument type="tagged" tag="sylius_mailer.email_modifier" />
         </service>
 
-        <service id="Sylius\Bundle\MailerBundle\Command\DebugMailerCommand" autoconfigure="true">
+        <service id="Sylius\Bundle\MailerBundle\Cli\DebugMailerCommand" autoconfigure="true">
             <argument>%sylius.mailer.sender_name%</argument>
             <argument>%sylius.mailer.sender_address%</argument>
             <argument>%sylius.mailer.emails%</argument>

--- a/src/Bundle/test/config/packages/framework.yaml
+++ b/src/Bundle/test/config/packages/framework.yaml
@@ -4,3 +4,5 @@ framework:
     default_locale: "%locale%"
     http_method_override: true
     test: ~
+    translator:
+        default_path: '%kernel.project_dir%/translations'

--- a/src/Bundle/test/config/packages/test/sylius_mailer.yaml
+++ b/src/Bundle/test/config/packages/test/sylius_mailer.yaml
@@ -5,8 +5,13 @@ sylius_mailer:
     sender_adapter: sylius.email_sender.adapter.symfony_mailer
     emails:
         test_email:
+            subject: 'Hardcoded subject'
             template: 'Email/test.html.twig'
         test_email_with_data:
+            subject: 'sylius_mailer.test_email_with_data.subject'
             template: 'Email/testWithData.html.twig'
         test_modified_email:
             template: 'Email/test.html.twig'
+        test_disabled_email:
+            template: 'Email/test.html.twig'
+            enabled: false

--- a/src/Bundle/test/translations/messages.en.yaml
+++ b/src/Bundle/test/translations/messages.en.yaml
@@ -1,0 +1,3 @@
+sylius_mailer:
+    test_email_with_data:
+        subject: Subject for email with data

--- a/src/Bundle/tests/Cli/DebugMailerCommandTest.php
+++ b/src/Bundle/tests/Cli/DebugMailerCommandTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\Bundle\MailerBundle\tests\Cli;

--- a/src/Bundle/tests/Cli/DebugMailerCommandTest.php
+++ b/src/Bundle/tests/Cli/DebugMailerCommandTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\MailerBundle\tests\Cli;
+
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+final class DebugMailerCommandTest extends KernelTestCase
+{
+    private CommandTester $commandTester;
+
+    protected function setUp(): void
+    {
+        $kernel = self::bootKernel();
+        $application = new Application($kernel);
+
+        $command = $application->find('sylius:debug:mailer');
+        $this->commandTester = new CommandTester($command);
+    }
+
+    /** @test */
+    public function it_lists_all_configured_emails_and_sender_data(): void
+    {
+        $this->commandTester->execute([]);
+        $this->commandTester->assertCommandIsSuccessful();
+
+        $output = $this->commandTester->getDisplay();
+        $this->assertStringContainsString('Name    Sender', $output);
+        $this->assertStringContainsString('Email   sender@example.com', $output);
+        $this->assertStringContainsString(
+            '| test_email           | Email/test.html.twig         | yes     | Hardcoded subject           |',
+            $output,
+        );
+        $this->assertStringContainsString(
+            '| test_email_with_data | Email/testWithData.html.twig | yes     | Subject for email with data |',
+            $output,
+        );
+        $this->assertStringContainsString(
+            '| test_modified_email  | Email/test.html.twig         | yes     |',
+            $output,
+        );
+        $this->assertStringContainsString(
+            '| test_disabled_email  | Email/test.html.twig         | no      |',
+            $output,
+        );
+    }
+
+    /** @test */
+    public function it_shows_configured_email_details(): void
+    {
+        $this->commandTester->execute(['email' => 'test_email_with_data']);
+        $this->commandTester->assertCommandIsSuccessful();
+
+        $output = $this->commandTester->getDisplay();
+        $this->assertStringContainsString('Email: test_email_with_data', $output);
+        $this->assertStringContainsString('Subject: Subject for email with data', $output);
+        $this->assertStringContainsString('Enabled: yes', $output);
+        $this->assertStringContainsString('Test email body. Data: {{ data }}.', $output);
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

I was playing with SyliusMailerBundle a little bit yesterday and wanted to get information about emails that are configured. As it is a project using Sylius with some customizations, my first thought was "so what, I'm gonna browse yaml files like some kind of animal?!". My second thought was "but I can use `debug:config sylius_mailer` command to dump the bundle configuration which did the trick but looked rough and ugly. 

So my final resolution was - what if we have a nice debug command for the configured emails? And I wrote it. There are obviously a lot of things to improve (I still don't know if dumping the email template brings any value 🤷‍♂️), but looks nicer 🚀 

Let me know what you think about it 🫡

<img width="1091" alt="Zrzut ekranu 2023-01-18 o 23 30 41" src="https://user-images.githubusercontent.com/6212718/213450695-2c9c46d6-72e8-4f7d-8eeb-ef9b88858c67.png">

PS. Thanks @loic425 for the inspiration with debug serializer command - I definitely belive following the "it's useful for me, maybe it's useful for others" path is a good idea 🖖 
