### PR TITLE
Remove deprecated code from SenderInterface

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,16 +13,13 @@ on:
 jobs:
     tests:
         runs-on: ubuntu-latest
-        name: "PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, Twig ${{ matrix.twig }}"
+        name: "PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}"
         strategy:
             fail-fast: false
             matrix:
                 php: ["8.1", "8.2", "8.3"]
                 symfony: ["^5.4", "^6.4", "^7.0"]
-                twig: ["^2.12", "^3.3"]
                 exclude:
-                    - twig: "^2.12"
-                      symfony: "^7.0"
                     - php: "8.1"
                       symfony: "^7.0"
 
@@ -36,21 +33,14 @@ jobs:
                 with:
                     php-version: "${{ matrix.php }}"
                     coverage: none
+                    tools: 'composer:v2, flex'
 
             -
                 name: Restrict Symfony version
                 if: matrix.symfony != ''
                 run: |
-                    composer global config --no-plugins allow-plugins.symfony/flex true
-                    composer global require --no-progress --no-scripts --no-plugins "symfony/flex:^1.10"
                     composer config extra.symfony.require "${{ matrix.symfony }}"
                     (cd src/Component && composer config extra.symfony.require "${{ matrix.symfony }}")
-
-            -
-                name: Restrict Twig version
-                if: matrix.twig != ''
-                run: |
-                    composer require "twig/twig:${{ matrix.twig }}" --no-update --no-scripts
 
             -
                 name: Install dependencies

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -18,5 +18,3 @@ parameters:
 
     ignoreErrors:
         - '/Property Sylius\\Component\\Mailer\\Model\\Email\:\:\$id is never written\, only read\./'
-        - '/PHPDoc tag \@param references unknown parameter\: \$bccRecipients/'
-        - '/PHPDoc tag \@param references unknown parameter\: \$ccRecipients/'

--- a/src/Component/Sender/Sender.php
+++ b/src/Component/Sender/Sender.php
@@ -46,9 +46,9 @@ final class Sender implements SenderInterface
         array $data = [],
         array $attachments = [],
         array $replyTo = [],
+        array $ccRecipients = [],
+        array $bccRecipients = [],
     ): void {
-        $arguments = func_get_args();
-
         Assert::allStringNotEmpty($recipients);
 
         $email = $this->provider->getEmail($code);
@@ -65,12 +65,7 @@ final class Sender implements SenderInterface
 
         $renderedEmail = $this->rendererAdapter->render($email, $data);
 
-        if (count($arguments) > 5 && $this->senderAdapter instanceof CcAwareAdapterInterface) {
-            /** @var array<string> $ccRecipients */
-            $ccRecipients = $arguments[5] ?? [];
-            /** @var array<string> $bccRecipients */
-            $bccRecipients = $arguments[6] ?? [];
-
+        if ($this->senderAdapter instanceof CcAwareAdapterInterface) {
             $this->senderAdapter->sendWithCC(
                 $recipients,
                 $senderAddress,

--- a/src/Component/Sender/SenderInterface.php
+++ b/src/Component/Sender/SenderInterface.php
@@ -16,8 +16,6 @@ namespace Sylius\Component\Mailer\Sender;
 interface SenderInterface
 {
     /**
-     * @deprecated using this method without 2 last arguments ($ccRecipients and $bccRecipients) is deprecated since 1.8 and won't be possible since 2.0
-     *
      * @param string[]|null[] $recipients A list of email addresses to receive the message. Providing null or empty string in the list of recipients is deprecated and will be removed in SyliusMailerBundle 2.0
      * @param string[] $attachments A list of file paths to attach to the message.
      * @param string[] $replyTo A list of email addresses to set as the Reply-To address for the message.
@@ -30,5 +28,7 @@ interface SenderInterface
         array $data = [],
         array $attachments = [],
         array $replyTo = [],
+        array $ccRecipients = [],
+        array $bccRecipients = [],
     ): void;
 }

--- a/src/Component/spec/Sender/SenderSpec.php
+++ b/src/Component/spec/Sender/SenderSpec.php
@@ -99,7 +99,7 @@ final class SenderSpec extends ObjectBehavior
         EmailProviderInterface $provider,
         RenderedEmail $renderedEmail,
         RendererAdapterInterface $rendererAdapter,
-        SenderAdapterInterface $senderAdapter,
+        CcAwareSenderAdapterInterface $senderAdapter,
         DefaultSettingsProviderInterface $defaultSettingsProvider,
         EmailModifierInterface $emailModifier,
     ): void {

--- a/src/Component/spec/Sender/SenderSpec.php
+++ b/src/Component/spec/Sender/SenderSpec.php
@@ -21,26 +21,21 @@ use Sylius\Component\Mailer\Provider\DefaultSettingsProviderInterface;
 use Sylius\Component\Mailer\Provider\EmailProviderInterface;
 use Sylius\Component\Mailer\Renderer\Adapter\AdapterInterface as RendererAdapterInterface;
 use Sylius\Component\Mailer\Renderer\RenderedEmail;
-use Sylius\Component\Mailer\Sender\Adapter\CcAwareAdapterInterface as SenderAdapterInterface;
+use Sylius\Component\Mailer\Sender\Adapter\AdapterInterface as SenderAdapterInterface;
+use Sylius\Component\Mailer\Sender\Adapter\CcAwareAdapterInterface as CcAwareSenderAdapterInterface;
 
 final class SenderSpec extends ObjectBehavior
 {
-    function let(
+    function it_sends_an_email_through_the_adapter(
         RendererAdapterInterface $rendererAdapter,
         SenderAdapterInterface $senderAdapter,
         EmailProviderInterface $provider,
         DefaultSettingsProviderInterface $defaultSettingsProvider,
+        EmailInterface $email,
+        RenderedEmail $renderedEmail,
     ): void {
         $this->beConstructedWith($rendererAdapter, $senderAdapter, $provider, $defaultSettingsProvider);
-    }
 
-    function it_sends_an_email_through_the_adapter(
-        EmailInterface $email,
-        EmailProviderInterface $provider,
-        RenderedEmail $renderedEmail,
-        RendererAdapterInterface $rendererAdapter,
-        SenderAdapterInterface $senderAdapter,
-    ): void {
         $provider->getEmail('bar')->willReturn($email);
         $email->isEnabled()->willReturn(true);
         $email->getSenderAddress()->willReturn('sender@example.com');
@@ -49,6 +44,7 @@ final class SenderSpec extends ObjectBehavior
         $data = ['foo' => 2];
 
         $rendererAdapter->render($email, ['foo' => 2])->willReturn($renderedEmail);
+
         $senderAdapter->send(
             ['john@example.com'],
             'sender@example.com',
@@ -60,16 +56,19 @@ final class SenderSpec extends ObjectBehavior
             [],
         )->shouldBeCalled();
 
-        $this->send('bar', ['john@example.com'], $data, [], []);
+        $this->send('bar', ['john@example.com'], $data);
     }
 
     function it_sends_an_email_with_cc_and_bcc_through_the_adapter(
-        EmailInterface $email,
-        EmailProviderInterface $provider,
-        RenderedEmail $renderedEmail,
         RendererAdapterInterface $rendererAdapter,
-        SenderAdapterInterface $senderAdapter,
+        CcAwareSenderAdapterInterface $senderAdapter,
+        EmailProviderInterface $provider,
+        DefaultSettingsProviderInterface $defaultSettingsProvider,
+        EmailInterface $email,
+        RenderedEmail $renderedEmail,
     ): void {
+        $this->beConstructedWith($rendererAdapter, $senderAdapter, $provider, $defaultSettingsProvider);
+
         $provider->getEmail('bar')->willReturn($email);
         $email->isEnabled()->willReturn(true);
         $email->getSenderAddress()->willReturn('sender@example.com');
@@ -78,6 +77,7 @@ final class SenderSpec extends ObjectBehavior
         $data = ['foo' => 2];
 
         $rendererAdapter->render($email, ['foo' => 2])->willReturn($renderedEmail);
+        $senderAdapter->send(Argument::cetera())->shouldNotBeCalled();
         $senderAdapter->sendWithCC(
             ['john@example.com'],
             'sender@example.com',
@@ -133,11 +133,14 @@ final class SenderSpec extends ObjectBehavior
     }
 
     function it_does_not_send_disabled_emails(
-        EmailInterface $email,
-        EmailProviderInterface $provider,
         RendererAdapterInterface $rendererAdapter,
         SenderAdapterInterface $senderAdapter,
+        EmailProviderInterface $provider,
+        DefaultSettingsProviderInterface $defaultSettingsProvider,
+        EmailInterface $email,
     ): void {
+        $this->beConstructedWith($rendererAdapter, $senderAdapter, $provider, $defaultSettingsProvider);
+
         $provider->getEmail('bar')->willReturn($email);
         $email->isEnabled()->willReturn(false);
 
@@ -150,7 +153,11 @@ final class SenderSpec extends ObjectBehavior
     function it_throws_an_exception_if_wrong_value_is_provided_as_recipient_email(
         RendererAdapterInterface $rendererAdapter,
         SenderAdapterInterface $senderAdapter,
+        EmailProviderInterface $provider,
+        DefaultSettingsProviderInterface $defaultSettingsProvider,
     ): void {
+        $this->beConstructedWith($rendererAdapter, $senderAdapter, $provider, $defaultSettingsProvider);
+
         $rendererAdapter->render(Argument::any())->shouldNotBeCalled();
         $senderAdapter->send(Argument::any())->shouldNotBeCalled();
 

--- a/src/Component/spec/Sender/SenderSpec.php
+++ b/src/Component/spec/Sender/SenderSpec.php
@@ -26,16 +26,22 @@ use Sylius\Component\Mailer\Sender\Adapter\CcAwareAdapterInterface as CcAwareSen
 
 final class SenderSpec extends ObjectBehavior
 {
-    function it_sends_an_email_through_the_adapter(
+    function let(
         RendererAdapterInterface $rendererAdapter,
         SenderAdapterInterface $senderAdapter,
         EmailProviderInterface $provider,
         DefaultSettingsProviderInterface $defaultSettingsProvider,
+    ): void {
+        $this->beConstructedWith($rendererAdapter, $senderAdapter, $provider, $defaultSettingsProvider);
+    }
+
+    function it_sends_an_email_through_the_adapter(
+        RendererAdapterInterface $rendererAdapter,
+        SenderAdapterInterface $senderAdapter,
+        EmailProviderInterface $provider,
         EmailInterface $email,
         RenderedEmail $renderedEmail,
     ): void {
-        $this->beConstructedWith($rendererAdapter, $senderAdapter, $provider, $defaultSettingsProvider);
-
         $provider->getEmail('bar')->willReturn($email);
         $email->isEnabled()->willReturn(true);
         $email->getSenderAddress()->willReturn('sender@example.com');
@@ -95,13 +101,13 @@ final class SenderSpec extends ObjectBehavior
     }
 
     function it_sends_a_modified_email_with_cc_and_bcc_through_the_adapter(
-        EmailInterface $email,
-        EmailProviderInterface $provider,
-        RenderedEmail $renderedEmail,
         RendererAdapterInterface $rendererAdapter,
         CcAwareSenderAdapterInterface $senderAdapter,
+        EmailProviderInterface $provider,
         DefaultSettingsProviderInterface $defaultSettingsProvider,
         EmailModifierInterface $emailModifier,
+        EmailInterface $email,
+        RenderedEmail $renderedEmail,
     ): void {
         $this->beConstructedWith($rendererAdapter, $senderAdapter, $provider, $defaultSettingsProvider, $emailModifier);
 
@@ -136,11 +142,8 @@ final class SenderSpec extends ObjectBehavior
         RendererAdapterInterface $rendererAdapter,
         SenderAdapterInterface $senderAdapter,
         EmailProviderInterface $provider,
-        DefaultSettingsProviderInterface $defaultSettingsProvider,
         EmailInterface $email,
     ): void {
-        $this->beConstructedWith($rendererAdapter, $senderAdapter, $provider, $defaultSettingsProvider);
-
         $provider->getEmail('bar')->willReturn($email);
         $email->isEnabled()->willReturn(false);
 
@@ -153,11 +156,7 @@ final class SenderSpec extends ObjectBehavior
     function it_throws_an_exception_if_wrong_value_is_provided_as_recipient_email(
         RendererAdapterInterface $rendererAdapter,
         SenderAdapterInterface $senderAdapter,
-        EmailProviderInterface $provider,
-        DefaultSettingsProviderInterface $defaultSettingsProvider,
     ): void {
-        $this->beConstructedWith($rendererAdapter, $senderAdapter, $provider, $defaultSettingsProvider);
-
         $rendererAdapter->render(Argument::any())->shouldNotBeCalled();
         $senderAdapter->send(Argument::any())->shouldNotBeCalled();
 


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | https://github.com/Sylius/SyliusMailerBundle/pull/152
| License         | MIT

We neglected to remove outdated code before the 2.0 release