### PR TITLE
Manage address/name recipients array in SymfonyMailerAdapter

### DIFF
--- a/src/Bundle/Sender/Adapter/SymfonyMailerAdapter.php
+++ b/src/Bundle/Sender/Adapter/SymfonyMailerAdapter.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\MailerBundle\Sender\Adapter;
 
+use Egulias\EmailValidator\EmailValidator;
+use Egulias\EmailValidator\Validation\RFCValidation;
 use Sylius\Component\Mailer\Event\EmailSendEvent;
 use Sylius\Component\Mailer\Model\EmailInterface;
 use Sylius\Component\Mailer\Renderer\RenderedEmail;
@@ -99,13 +101,13 @@ final class SymfonyMailerAdapter extends AbstractAdapter implements CcAwareAdapt
         $message = (new Email())
             ->subject($renderedEmail->getSubject())
             ->from(new Address($senderAddress, $senderName))
-            ->to(...$recipients)
+            ->to(...$this->formatRecipients($recipients))
             ->replyTo(...$replyTo)
             ->html($renderedEmail->getBody())
         ;
 
-        $message->addCc(...$ccRecipients);
-        $message->addBcc(...$bccRecipients);
+        $message->addCc(...$this->formatRecipients($ccRecipients));
+        $message->addBcc(...$this->formatRecipients($bccRecipients));
 
         foreach ($attachments as $attachment) {
             $message->attachFromPath($attachment);
@@ -118,5 +120,30 @@ final class SymfonyMailerAdapter extends AbstractAdapter implements CcAwareAdapt
         $this->mailer->send($message);
 
         $this->dispatcher?->dispatch($emailSendEvent, SyliusMailerEvents::EMAIL_POST_SEND);
+    }
+
+    /**
+     * There are two kinds of recipient array syntax that can be passed to the send method:
+     * - Only email addresses: ['john.doe@mail.com', 'jane.smith@mail.com']
+     * - Email addresses with names: ['john.doe@mail.com' => 'John Doe', 'jane.smith@mail.com' => 'Jane Smith']
+     *
+     * Since Symfony\Mailer requires an instance of Symfony\Component\Mime\Address or a valid email string for each recipient,
+     * we need to transform the recipient array where keys are address and values are name to an array of Address object.
+     */
+    protected function formatRecipients(array $recipients): array
+    {
+        $transformedRecipients = [];
+        $validator = new EmailValidator();
+        foreach ($recipients as $addressOrKey => $nameOrAddress) {
+            if (\is_string($addressOrKey) && $validator->isValid($addressOrKey, new RFCValidation())) {
+                $transformedRecipients[] = new Address($addressOrKey, $nameOrAddress);
+
+                continue;
+            }
+
+            $transformedRecipients[] = $nameOrAddress;
+        }
+
+        return $transformedRecipients;
     }
 }

--- a/src/Component/spec/Sender/SenderSpec.php
+++ b/src/Component/spec/Sender/SenderSpec.php
@@ -63,6 +63,35 @@ final class SenderSpec extends ObjectBehavior
         $this->send('bar', ['john@example.com'], $data, [], []);
     }
 
+    function it_sends_an_email_and_name_pair_through_the_adapter(
+        EmailInterface $email,
+        EmailProviderInterface $provider,
+        RenderedEmail $renderedEmail,
+        RendererAdapterInterface $rendererAdapter,
+        SenderAdapterInterface $senderAdapter,
+    ): void {
+        $provider->getEmail('bar')->willReturn($email);
+        $email->isEnabled()->willReturn(true);
+        $email->getSenderAddress()->willReturn('sender@example.com');
+        $email->getSenderName()->willReturn('Sender');
+
+        $data = ['foo' => 2];
+
+        $rendererAdapter->render($email, ['foo' => 2])->willReturn($renderedEmail);
+        $senderAdapter->send(
+            ['john@example.com' => 'John Doe'],
+            'sender@example.com',
+            'Sender',
+            $renderedEmail,
+            $email,
+            $data,
+            [],
+            [],
+        )->shouldBeCalled();
+
+        $this->send('bar', ['john@example.com' => 'John Doe'], $data, [], []);
+    }
+
     function it_sends_an_email_with_cc_and_bcc_through_the_adapter(
         EmailInterface $email,
         EmailProviderInterface $provider,
@@ -92,6 +121,37 @@ final class SenderSpec extends ObjectBehavior
         )->shouldBeCalled();
 
         $this->send('bar', ['john@example.com'], $data, [], [], ['cc@example.com'], ['bcc@example.com']);
+    }
+
+    function it_sends_an_email_with_cc_and_name_pair_and_bcc_and_name_pair_through_the_adapter(
+        EmailInterface $email,
+        EmailProviderInterface $provider,
+        RenderedEmail $renderedEmail,
+        RendererAdapterInterface $rendererAdapter,
+        SenderAdapterInterface $senderAdapter,
+    ): void {
+        $provider->getEmail('bar')->willReturn($email);
+        $email->isEnabled()->willReturn(true);
+        $email->getSenderAddress()->willReturn('sender@example.com');
+        $email->getSenderName()->willReturn('Sender');
+
+        $data = ['foo' => 2];
+
+        $rendererAdapter->render($email, ['foo' => 2])->willReturn($renderedEmail);
+        $senderAdapter->sendWithCC(
+            ['john@example.com'],
+            'sender@example.com',
+            'Sender',
+            $renderedEmail,
+            $email,
+            $data,
+            [],
+            [],
+            ['cc@example.com' => 'CC'],
+            ['bcc@example.com' => 'BCC'],
+        )->shouldBeCalled();
+
+        $this->send('bar', ['john@example.com'], $data, [], [], ['cc@example.com' => 'CC'], ['bcc@example.com' => 'BCC']);
     }
 
     function it_sends_a_modified_email_with_cc_and_bcc_through_the_adapter(


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | no
| License         | MIT


## Context
I'm currently working on the upgrade of a Sylius v1.10 to Sylius 1.12. Since Sylius use Symfony Mailer instead of Swift Mailer, we encounter the following bug: before the upgrade, we use 
```php
['john.doe@mail.com' => 'John Doe', 'jane.smith@mail.com' => 'Jane Smith']
```
array for the `$recipients ` parameter of the `\Sylius\Component\Mailer\Sender\Sender::send`  method, and it was working like a charm. 


## Problem
After the upgrade, Symfony Mailer `\Symfony\Component\Mime\Email` object used in `\Sylius\Bundle\MailerBundle\Sender\Adapter\SymfonyMailerAdapter::sendMessage`  is looking for a `\Symfony\Component\Mime\Address`  objects or strings. With an array like above, it tries to use '`John Doe'` or `'Jane Smith'` as email and the following exception is thrown:

<img width="1036" alt="image" src="https://github.com/user-attachments/assets/1e3f552a-888f-41ff-a853-b55dd13a171f">

## Fix

I've added a function to format `address => name` like array value to an `Address` object. Only `address` value are not touched. 