### PR TITLE
Add native typed properties and remove redundant declarations

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -16,6 +16,5 @@ parameters:
         - %currentWorkingDirectory%/tests/*
 
     ignoreErrors:
-        - '/Property Sylius\\Component\\Mailer\\Model\\Email\:\:\$id is never written\, only read\./'
         - '/PHPDoc tag \@param references unknown parameter\: \$bccRecipients/'
         - '/PHPDoc tag \@param references unknown parameter\: \$ccRecipients/'

--- a/src/Bundle/Renderer/Adapter/EmailDefaultAdapter.php
+++ b/src/Bundle/Renderer/Adapter/EmailDefaultAdapter.php
@@ -16,15 +16,9 @@ namespace Sylius\Bundle\MailerBundle\Renderer\Adapter;
 use Sylius\Component\Mailer\Model\EmailInterface;
 use Sylius\Component\Mailer\Renderer\Adapter\AbstractAdapter;
 use Sylius\Component\Mailer\Renderer\RenderedEmail;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 final class EmailDefaultAdapter extends AbstractAdapter
 {
-    public function __construct(?EventDispatcherInterface $dispatcher = null)
-    {
-        $this->dispatcher = $dispatcher;
-    }
-
     public function render(EmailInterface $email, array $data = []): RenderedEmail
     {
         throw new \RuntimeException(sprintf(

--- a/src/Component/Event/EmailSendEvent.php
+++ b/src/Component/Event/EmailSendEvent.php
@@ -19,12 +19,11 @@ use Symfony\Contracts\EventDispatcher\Event;
 final class EmailSendEvent extends Event
 {
     /**
-     * @param mixed $message
      * @param string[] $recipients
      * @param string[] $replyTo
      */
     public function __construct(
-        protected $message,
+        protected mixed $message,
         protected EmailInterface $email,
         protected array $data,
         protected array $recipients = [],
@@ -42,10 +41,7 @@ final class EmailSendEvent extends Event
         return $this->email;
     }
 
-    /**
-     * @return mixed
-     */
-    public function getMessage()
+    public function getMessage(): mixed
     {
         return $this->message;
     }

--- a/src/Component/Model/Email.php
+++ b/src/Component/Model/Email.php
@@ -15,8 +15,7 @@ namespace Sylius\Component\Mailer\Model;
 
 final class Email implements EmailInterface
 {
-    /** @var mixed */
-    private $id;
+    private string|int|null $id = null;
 
     private ?string $code = null;
 
@@ -32,8 +31,7 @@ final class Email implements EmailInterface
 
     private ?string $senderAddress = null;
 
-    /** @return mixed */
-    public function getId()
+    public function getId(): string|int|null
     {
         return $this->id;
     }


### PR DESCRIPTION
- Add native `mixed` type to untyped properties (`Email::$id`, `EmailSendEvent::$message`) and their return types
- Remove redundant constructor in `EmailDefaultAdapter` (dispatcher is already set via `AbstractAdapter::setEventDispatcher()`)
- Remove PHPDoc annotations replaced by native types
- Remove obsolete PHPStan ignored error for `$id` property