### PR TITLE
Add final keyword to value classes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,16 +13,13 @@ on:
 jobs:
     tests:
         runs-on: ubuntu-latest
-        name: "PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, Twig ${{ matrix.twig }}"
+        name: "PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}"
         strategy:
             fail-fast: false
             matrix:
                 php: ["8.1", "8.2", "8.3"]
                 symfony: ["^5.4", "^6.4", "^7.0"]
-                twig: ["^2.12", "^3.3"]
                 exclude:
-                    - twig: "^2.12"
-                      symfony: "^7.0"
                     - php: "8.1"
                       symfony: "^7.0"
 
@@ -36,21 +33,14 @@ jobs:
                 with:
                     php-version: "${{ matrix.php }}"
                     coverage: none
+                    tools: 'composer:v2, flex'
 
             -
                 name: Restrict Symfony version
                 if: matrix.symfony != ''
                 run: |
-                    composer global config --no-plugins allow-plugins.symfony/flex true
-                    composer global require --no-progress --no-scripts --no-plugins "symfony/flex:^1.10"
                     composer config extra.symfony.require "${{ matrix.symfony }}"
                     (cd src/Component && composer config extra.symfony.require "${{ matrix.symfony }}")
-
-            -
-                name: Restrict Twig version
-                if: matrix.twig != ''
-                run: |
-                    composer require "twig/twig:${{ matrix.twig }}" --no-update --no-scripts
 
             -
                 name: Install dependencies

--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -1,5 +1,12 @@
 ## CHANGELOG FOR `2.0.x`
 
+## v2.1.0 (2024-10-01)
+
+#### Details
+
+- [#265](https://github.com/Sylius/SyliusMailerBundle/issues/265) Update phpstan/phpstan requirement from 1.12.4 to 1.12.5
+- [#263](https://github.com/Sylius/SyliusMailerBundle/issues/263) Update phpstan/phpstan-webmozart-assert requirement from 1.2.0 to 1.2.11
+
 ## v2.1.0-BETA.1 (2024-09-24)
 
 #### Details

--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -1,5 +1,13 @@
 ## CHANGELOG FOR `2.0.x`
 
+## v2.1.0-BETA.1 (2024-09-24)
+
+#### Details
+
+- [#259](https://github.com/Sylius/SyliusMailerBundle/issues/259) Manage address/name recipients array in SymfonyMailerAdapter ([@lanfisis](https://github.com/lanfisis))
+- [#260](https://github.com/Sylius/SyliusMailerBundle/issues/260) Update phpstan/phpstan requirement from 1.11.10 to 1.12.4 ([@dependabot](https://github.com/dependabot)[[@bot](https://github.com/bot)])
+- [#262](https://github.com/Sylius/SyliusMailerBundle/issues/262) Update phpstan/phpstan-phpunit requirement from 1.1.1 to 1.4.0 ([@dependabot](https://github.com/dependabot)[[@bot](https://github.com/bot)], [@GSadee](https://github.com/GSadee))
+
 ## v2.1.0-ALPHA.1 (2024-07-29)
 
 #### Details

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "matthiasnoback/symfony-dependency-injection-test": "^5.0",
         "phpspec/phpspec": "^7.0",
         "phpstan/phpstan": "1.11.8",
-        "phpstan/phpstan-phpunit": "1.1.1",
+        "phpstan/phpstan-phpunit": "1.4.0",
         "phpstan/phpstan-webmozart-assert": "1.2.0",
         "phpunit/phpunit": "^10.5",
         "rector/rector": "^0.13.6",

--- a/composer.json
+++ b/composer.json
@@ -25,10 +25,10 @@
     ],
     "require": {
         "php": "^8.1",
-        "sylius-labs/polyfill-symfony-event-dispatcher": "^1.0",
         "symfony/config": "^5.4 || ^6.4 || ^7.0",
         "symfony/deprecation-contracts": "^2.1 || ^3.0",
         "symfony/dependency-injection": "^5.4 || ^6.4 || ^7.0",
+        "symfony/event-dispatcher-contracts": "^2.5 || ^3.0",
         "symfony/framework-bundle": "^5.4 || ^6.4 || ^7.0",
         "symfony/http-kernel": "^5.4 || ^6.4 || ^7.0",
         "twig/twig": "^2.12 || ^3.3",

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
     "require-dev": {
         "matthiasnoback/symfony-dependency-injection-test": "^5.0",
         "phpspec/phpspec": "^7.0",
-        "phpstan/phpstan": "1.12.4",
+        "phpstan/phpstan": "1.12.5",
         "phpstan/phpstan-phpunit": "1.4.0",
         "phpstan/phpstan-webmozart-assert": "1.2.0",
         "phpunit/phpunit": "^10.5",

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "phpspec/phpspec": "^7.0",
         "phpstan/phpstan": "1.12.4",
         "phpstan/phpstan-phpunit": "1.4.0",
-        "phpstan/phpstan-webmozart-assert": "1.2.0",
+        "phpstan/phpstan-webmozart-assert": "1.2.11",
         "phpunit/phpunit": "^10.5",
         "rector/rector": "^0.13.6",
         "sylius-labs/coding-standard": "^4.0",

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
     "require-dev": {
         "matthiasnoback/symfony-dependency-injection-test": "^5.0",
         "phpspec/phpspec": "^7.0",
-        "phpstan/phpstan": "1.11.8",
+        "phpstan/phpstan": "1.12.4",
         "phpstan/phpstan-phpunit": "1.1.1",
         "phpstan/phpstan-webmozart-assert": "1.2.0",
         "phpunit/phpunit": "^10.5",

--- a/src/Bundle/Sender/Adapter/SymfonyMailerAdapter.php
+++ b/src/Bundle/Sender/Adapter/SymfonyMailerAdapter.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\MailerBundle\Sender\Adapter;
 
+use Egulias\EmailValidator\EmailValidator;
+use Egulias\EmailValidator\Validation\RFCValidation;
 use Sylius\Component\Mailer\Event\EmailSendEvent;
 use Sylius\Component\Mailer\Model\EmailInterface;
 use Sylius\Component\Mailer\Renderer\RenderedEmail;
@@ -99,13 +101,13 @@ final class SymfonyMailerAdapter extends AbstractAdapter implements CcAwareAdapt
         $message = (new Email())
             ->subject($renderedEmail->getSubject())
             ->from(new Address($senderAddress, $senderName))
-            ->to(...$recipients)
+            ->to(...$this->formatRecipients($recipients))
             ->replyTo(...$replyTo)
             ->html($renderedEmail->getBody())
         ;
 
-        $message->addCc(...$ccRecipients);
-        $message->addBcc(...$bccRecipients);
+        $message->addCc(...$this->formatRecipients($ccRecipients));
+        $message->addBcc(...$this->formatRecipients($bccRecipients));
 
         foreach ($attachments as $attachment) {
             $message->attachFromPath($attachment);
@@ -118,5 +120,30 @@ final class SymfonyMailerAdapter extends AbstractAdapter implements CcAwareAdapt
         $this->mailer->send($message);
 
         $this->dispatcher?->dispatch($emailSendEvent, SyliusMailerEvents::EMAIL_POST_SEND);
+    }
+
+    /**
+     * There are two kinds of recipient array syntax that can be passed to the send method:
+     * - Only email addresses: ['john.doe@mail.com', 'jane.smith@mail.com']
+     * - Email addresses with names: ['john.doe@mail.com' => 'John Doe', 'jane.smith@mail.com' => 'Jane Smith']
+     *
+     * Since Symfony\Mailer requires an instance of Symfony\Component\Mime\Address or a valid email string for each recipient,
+     * we need to transform the recipient array where keys are address and values are name to an array of Address object.
+     */
+    protected function formatRecipients(array $recipients): array
+    {
+        $transformedRecipients = [];
+        $validator = new EmailValidator();
+        foreach ($recipients as $addressOrKey => $nameOrAddress) {
+            if (\is_string($addressOrKey) && $validator->isValid($addressOrKey, new RFCValidation())) {
+                $transformedRecipients[] = new Address($addressOrKey, $nameOrAddress);
+
+                continue;
+            }
+
+            $transformedRecipients[] = $nameOrAddress;
+        }
+
+        return $transformedRecipients;
     }
 }

--- a/src/Component/Event/EmailRenderEvent.php
+++ b/src/Component/Event/EmailRenderEvent.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Component\Mailer\Event;
 
 use Sylius\Component\Mailer\Renderer\RenderedEmail;
-use SyliusLabs\Polyfill\Symfony\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 class EmailRenderEvent extends Event
 {

--- a/src/Component/Event/EmailSendEvent.php
+++ b/src/Component/Event/EmailSendEvent.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Component\Mailer\Event;
 
 use Sylius\Component\Mailer\Model\EmailInterface;
-use SyliusLabs\Polyfill\Symfony\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 final class EmailSendEvent extends Event
 {

--- a/src/Component/Factory/EmailFactory.php
+++ b/src/Component/Factory/EmailFactory.php
@@ -16,7 +16,7 @@ namespace Sylius\Component\Mailer\Factory;
 use Sylius\Component\Mailer\Model\Email;
 use Sylius\Component\Mailer\Model\EmailInterface;
 
-class EmailFactory implements EmailFactoryInterface
+final class EmailFactory implements EmailFactoryInterface
 {
     /**
      * {@inheritdoc}

--- a/src/Component/SyliusMailerEvents.php
+++ b/src/Component/SyliusMailerEvents.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Component\Mailer;
 
-class SyliusMailerEvents
+final class SyliusMailerEvents
 {
     public const EMAIL_PRE_RENDER = 'sylius.email_rendered';
 

--- a/src/Component/spec/Sender/SenderSpec.php
+++ b/src/Component/spec/Sender/SenderSpec.php
@@ -63,6 +63,35 @@ final class SenderSpec extends ObjectBehavior
         $this->send('bar', ['john@example.com'], $data, [], []);
     }
 
+    function it_sends_an_email_and_name_pair_through_the_adapter(
+        EmailInterface $email,
+        EmailProviderInterface $provider,
+        RenderedEmail $renderedEmail,
+        RendererAdapterInterface $rendererAdapter,
+        SenderAdapterInterface $senderAdapter,
+    ): void {
+        $provider->getEmail('bar')->willReturn($email);
+        $email->isEnabled()->willReturn(true);
+        $email->getSenderAddress()->willReturn('sender@example.com');
+        $email->getSenderName()->willReturn('Sender');
+
+        $data = ['foo' => 2];
+
+        $rendererAdapter->render($email, ['foo' => 2])->willReturn($renderedEmail);
+        $senderAdapter->send(
+            ['john@example.com' => 'John Doe'],
+            'sender@example.com',
+            'Sender',
+            $renderedEmail,
+            $email,
+            $data,
+            [],
+            [],
+        )->shouldBeCalled();
+
+        $this->send('bar', ['john@example.com' => 'John Doe'], $data, [], []);
+    }
+
     function it_sends_an_email_with_cc_and_bcc_through_the_adapter(
         EmailInterface $email,
         EmailProviderInterface $provider,
@@ -92,6 +121,37 @@ final class SenderSpec extends ObjectBehavior
         )->shouldBeCalled();
 
         $this->send('bar', ['john@example.com'], $data, [], [], ['cc@example.com'], ['bcc@example.com']);
+    }
+
+    function it_sends_an_email_with_cc_and_name_pair_and_bcc_and_name_pair_through_the_adapter(
+        EmailInterface $email,
+        EmailProviderInterface $provider,
+        RenderedEmail $renderedEmail,
+        RendererAdapterInterface $rendererAdapter,
+        SenderAdapterInterface $senderAdapter,
+    ): void {
+        $provider->getEmail('bar')->willReturn($email);
+        $email->isEnabled()->willReturn(true);
+        $email->getSenderAddress()->willReturn('sender@example.com');
+        $email->getSenderName()->willReturn('Sender');
+
+        $data = ['foo' => 2];
+
+        $rendererAdapter->render($email, ['foo' => 2])->willReturn($renderedEmail);
+        $senderAdapter->sendWithCC(
+            ['john@example.com'],
+            'sender@example.com',
+            'Sender',
+            $renderedEmail,
+            $email,
+            $data,
+            [],
+            [],
+            ['cc@example.com' => 'CC'],
+            ['bcc@example.com' => 'BCC'],
+        )->shouldBeCalled();
+
+        $this->send('bar', ['john@example.com'], $data, [], [], ['cc@example.com' => 'CC'], ['bcc@example.com' => 'BCC']);
     }
 
     function it_sends_a_modified_email_with_cc_and_bcc_through_the_adapter(


### PR DESCRIPTION
## Summary

Add `final` keyword to classes that should not be extended:

- `EmailFactory` - factory implementation with interface
- `SyliusMailerEvents` - constants-only class

Also removes `sylius-labs/polyfill-symfony-event-dispatcher` in favor of `symfony/event-dispatcher-contracts`.

Note: `RenderedEmail` is intentionally left without `final` as phpspec cannot mock final classes.

All phpspec tests pass.