### PR TITLE
fix: Trim subject to avoid `=0A` characters in mail clients

### DIFF
--- a/src/Bundle/Renderer/Adapter/EmailTwigAdapter.php
+++ b/src/Bundle/Renderer/Adapter/EmailTwigAdapter.php
@@ -71,7 +71,7 @@ class EmailTwigAdapter extends AbstractAdapter
 
         $template = $this->twig->load((string) $email->getTemplate())->unwrap();
 
-        $subject = $template->renderBlock('subject', $data);
+        $subject = trim($template->renderBlock('subject', $data));
         $body = $template->renderBlock('body', $data);
 
         return new RenderedEmail($subject, $body);
@@ -84,7 +84,7 @@ class EmailTwigAdapter extends AbstractAdapter
         $subjectTemplate = $twig->createTemplate((string) $email->getSubject());
         $bodyTemplate = $twig->createTemplate((string) $email->getContent());
 
-        $subject = $subjectTemplate->render($data);
+        $subject = trim($subjectTemplate->render($data));
         $body = $bodyTemplate->render($data);
 
         return new RenderedEmail($subject, $body);


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets |
| License         | MIT


I've been anoyed with this since the beginning, let's move on.

`=0A` is the encoded version of `\n`, triming means no more trailing spaces or caret.


