### PR TITLE
Require PHP 8.2 and modernize codebase

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,13 +17,11 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: ["8.1", "8.2", "8.3"]
+                php: ["8.2", "8.3"]
                 symfony: ["^5.4", "^6.4", "^7.0"]
                 twig: ["^2.12", "^3.3"]
                 exclude:
                     - twig: "^2.12"
-                      symfony: "^7.0"
-                    - php: "8.1"
                       symfony: "^7.0"
 
         steps:

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "sylius-labs/polyfill-symfony-event-dispatcher": "^1.0",
         "symfony/config": "^5.4 || ^6.4 || ^7.0",
         "symfony/deprecation-contracts": "^2.1 || ^3.0",

--- a/src/Bundle/DependencyInjection/SyliusMailerExtension.php
+++ b/src/Bundle/DependencyInjection/SyliusMailerExtension.php
@@ -23,9 +23,6 @@ use Symfony\Component\HttpKernel\DependencyInjection\ConfigurableExtension;
 
 final class SyliusMailerExtension extends ConfigurableExtension
 {
-    /**
-     * {@inheritdoc}
-     */
     protected function loadInternal(array $mergedConfig, ContainerBuilder $container): void
     {
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));

--- a/src/Bundle/Renderer/Adapter/EmailDefaultAdapter.php
+++ b/src/Bundle/Renderer/Adapter/EmailDefaultAdapter.php
@@ -20,9 +20,6 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 final class EmailDefaultAdapter extends AbstractAdapter
 {
-    /** @var EventDispatcherInterface|null */
-    protected $dispatcher;
-
     public function __construct(?EventDispatcherInterface $dispatcher = null)
     {
         $this->dispatcher = $dispatcher;

--- a/src/Bundle/Renderer/Adapter/EmailTwigAdapter.php
+++ b/src/Bundle/Renderer/Adapter/EmailTwigAdapter.php
@@ -18,27 +18,19 @@ use Sylius\Component\Mailer\Model\EmailInterface;
 use Sylius\Component\Mailer\Renderer\Adapter\AbstractAdapter;
 use Sylius\Component\Mailer\Renderer\RenderedEmail;
 use Sylius\Component\Mailer\SyliusMailerEvents;
-use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Twig\Environment;
 use Twig\Loader\ArrayLoader;
 
 class EmailTwigAdapter extends AbstractAdapter
 {
-    /** @var Environment */
-    protected $twig;
-
-    /** @var EventDispatcherInterface|null */
-    protected $dispatcher;
-
-    public function __construct(Environment $twig, ?EventDispatcherInterface $dispatcher = null)
-    {
-        $this->twig = $twig;
+    public function __construct(
+        protected Environment $twig,
+        ?EventDispatcherInterface $dispatcher = null,
+    ) {
         $this->dispatcher = $dispatcher;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function render(EmailInterface $email, array $data = []): RenderedEmail
     {
         $renderedEmail = $this->getRenderedEmail($email, $data);

--- a/src/Bundle/Sender/Adapter/SymfonyMailerAdapter.php
+++ b/src/Bundle/Sender/Adapter/SymfonyMailerAdapter.php
@@ -32,9 +32,6 @@ final class SymfonyMailerAdapter extends AbstractAdapter implements CcAwareAdapt
     {
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function send(
         array $recipients,
         string $senderAddress,

--- a/src/Bundle/spec/Renderer/Adapter/EmailTwigAdapterSpec.php
+++ b/src/Bundle/spec/Renderer/Adapter/EmailTwigAdapterSpec.php
@@ -20,7 +20,7 @@ use Sylius\Component\Mailer\Model\EmailInterface;
 use Sylius\Component\Mailer\Renderer\Adapter\AbstractAdapter;
 use Sylius\Component\Mailer\Renderer\RenderedEmail;
 use Sylius\Component\Mailer\SyliusMailerEvents;
-use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Twig\Environment;
 use Twig\Template;
 use Twig\TemplateWrapper;

--- a/src/Bundle/spec/Sender/Adapter/SymfonyMailerAdapterSpec.php
+++ b/src/Bundle/spec/Sender/Adapter/SymfonyMailerAdapterSpec.php
@@ -20,11 +20,11 @@ use Sylius\Component\Mailer\Model\EmailInterface;
 use Sylius\Component\Mailer\Renderer\RenderedEmail;
 use Sylius\Component\Mailer\Sender\Adapter\AbstractAdapter;
 use Sylius\Component\Mailer\SyliusMailerEvents;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Mailer\Exception\TransportException;
 use Symfony\Component\Mailer\MailerInterface;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
-use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 final class SymfonyMailerAdapterSpec extends ObjectBehavior
 {

--- a/src/Component/Event/EmailRenderEvent.php
+++ b/src/Component/Event/EmailRenderEvent.php
@@ -18,16 +18,13 @@ use SyliusLabs\Polyfill\Symfony\EventDispatcher\Event;
 
 class EmailRenderEvent extends Event
 {
-    /** @var RenderedEmail */
-    protected $renderedEmail;
-
-    /** @var string[] */
-    protected $recipients;
-
-    public function __construct(RenderedEmail $renderedEmail, array $recipients = [])
-    {
-        $this->renderedEmail = $renderedEmail;
-        $this->recipients = $recipients;
+    /**
+     * @param string[] $recipients
+     */
+    public function __construct(
+        protected RenderedEmail $renderedEmail,
+        protected array $recipients = [],
+    ) {
     }
 
     public function getRenderedEmail(): RenderedEmail

--- a/src/Component/Factory/EmailFactory.php
+++ b/src/Component/Factory/EmailFactory.php
@@ -18,9 +18,6 @@ use Sylius\Component\Mailer\Model\EmailInterface;
 
 class EmailFactory implements EmailFactoryInterface
 {
-    /**
-     * {@inheritdoc}
-     */
     public function createNew(): EmailInterface
     {
         return new Email();

--- a/src/Component/Renderer/Adapter/AbstractAdapter.php
+++ b/src/Component/Renderer/Adapter/AbstractAdapter.php
@@ -13,12 +13,11 @@ declare(strict_types=1);
 
 namespace Sylius\Component\Mailer\Renderer\Adapter;
 
-use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 abstract class AbstractAdapter implements AdapterInterface
 {
-    /** @var EventDispatcherInterface|null */
-    protected $dispatcher;
+    protected ?EventDispatcherInterface $dispatcher = null;
 
     public function setEventDispatcher(EventDispatcherInterface $dispatcher): void
     {

--- a/src/Component/Renderer/RenderedEmail.php
+++ b/src/Component/Renderer/RenderedEmail.php
@@ -15,16 +15,10 @@ namespace Sylius\Component\Mailer\Renderer;
 
 class RenderedEmail
 {
-    /** @var string */
-    protected $subject;
-
-    /** @var string */
-    protected $body;
-
-    public function __construct(string $subject, string $body)
-    {
-        $this->subject = $subject;
-        $this->body = $body;
+    public function __construct(
+        protected string $subject,
+        protected string $body,
+    ) {
     }
 
     public function getSubject(): string

--- a/src/Component/Sender/Adapter/AbstractAdapter.php
+++ b/src/Component/Sender/Adapter/AbstractAdapter.php
@@ -13,12 +13,11 @@ declare(strict_types=1);
 
 namespace Sylius\Component\Mailer\Sender\Adapter;
 
-use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 abstract class AbstractAdapter implements AdapterInterface
 {
-    /** @var EventDispatcherInterface|null */
-    protected $dispatcher;
+    protected ?EventDispatcherInterface $dispatcher = null;
 
     public function setEventDispatcher(EventDispatcherInterface $dispatcher): void
     {

--- a/src/Component/Sender/Sender.php
+++ b/src/Component/Sender/Sender.php
@@ -37,9 +37,6 @@ final class Sender implements SenderInterface
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function send(
         string $code,
         array $recipients,

--- a/src/Component/composer.json
+++ b/src/Component/composer.json
@@ -24,7 +24,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.2",
         "webmozart/assert": "^1.9"
     },
     "require-dev": {


### PR DESCRIPTION
## Summary
- Require PHP 8.2 as minimum version (PHP 8.0 and 8.1 are EOL)
- Use constructor property promotion throughout
- Add typed properties where missing
- Remove deprecated `{@inheritdoc}` annotations