### PR TITLE
Drop Symfony 5.4 and Twig 2.x support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,11 +18,11 @@ jobs:
             fail-fast: false
             matrix:
                 php: ["8.2", "8.3"]
-                symfony: ["^5.4", "^6.4", "^7.0"]
+                symfony: ["^6.4", "^7.4"]
                 twig: ["^2.12", "^3.3"]
                 exclude:
                     - twig: "^2.12"
-                      symfony: "^7.0"
+                      symfony: "^7.4"
 
         steps:
             -

--- a/composer.json
+++ b/composer.json
@@ -25,12 +25,11 @@
     ],
     "require": {
         "php": "^8.2",
-        "sylius-labs/polyfill-symfony-event-dispatcher": "^1.0",
-        "symfony/config": "^5.4 || ^6.4 || ^7.0",
-        "symfony/deprecation-contracts": "^2.1 || ^3.0",
-        "symfony/dependency-injection": "^5.4 || ^6.4 || ^7.0",
-        "symfony/framework-bundle": "^5.4 || ^6.4 || ^7.0",
-        "symfony/http-kernel": "^5.4 || ^6.4 || ^7.0",
+        "symfony/config": "^6.4 || ^7.4",
+        "symfony/event-dispatcher-contracts": "^3.0",
+        "symfony/dependency-injection": "^6.4 || ^7.4",
+        "symfony/framework-bundle": "^6.4 || ^7.4",
+        "symfony/http-kernel": "^6.4 || ^7.4",
         "twig/twig": "^2.12 || ^3.3",
         "webmozart/assert": "^1.9"
     },
@@ -46,11 +45,11 @@
         "phpunit/phpunit": "^10.5",
         "rector/rector": "^0.13.6",
         "sylius-labs/coding-standard": "^4.0",
-        "symfony/console": "^5.4 || ^6.4 || ^7.0",
-        "symfony/dotenv": "^5.4 || ^6.4 || ^7.0",
-        "symfony/event-dispatcher": "^5.4 || ^6.4 || ^7.0",
-        "symfony/mailer": "^5.4 || ^6.4 || ^7.0",
-        "symfony/twig-bundle": "^5.4 || ^6.4 || ^7.0"
+        "symfony/console": "^6.4 || ^7.4",
+        "symfony/dotenv": "^6.4 || ^7.4",
+        "symfony/event-dispatcher": "^6.4 || ^7.4",
+        "symfony/mailer": "^6.4 || ^7.4",
+        "symfony/twig-bundle": "^6.4 || ^7.4"
     },
     "suggest": {
         "symfony/translation": "To use the translation features for testing purposes"

--- a/src/Component/Event/EmailRenderEvent.php
+++ b/src/Component/Event/EmailRenderEvent.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Component\Mailer\Event;
 
 use Sylius\Component\Mailer\Renderer\RenderedEmail;
-use SyliusLabs\Polyfill\Symfony\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 class EmailRenderEvent extends Event
 {

--- a/src/Component/Event/EmailSendEvent.php
+++ b/src/Component/Event/EmailSendEvent.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Component\Mailer\Event;
 
 use Sylius\Component\Mailer\Model\EmailInterface;
-use SyliusLabs\Polyfill\Symfony\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 final class EmailSendEvent extends Event
 {

--- a/src/Component/composer.json
+++ b/src/Component/composer.json
@@ -25,6 +25,7 @@
     ],
     "require": {
         "php": "^8.2",
+        "symfony/event-dispatcher-contracts": "^3.0",
         "webmozart/assert": "^1.9"
     },
     "require-dev": {


### PR DESCRIPTION
## Summary
- Drop Symfony 5.4 support (EOL December 2024)
- Require Symfony ^6.4 || ^7.4
- Remove sylius-labs/polyfill-symfony-event-dispatcher dependency
- Use Symfony\Contracts\EventDispatcher\Event directly