### PR TITLE
Add PHP 8.4 and 8.5 to CI matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: ["8.2", "8.3"]
+                php: ["8.2", "8.3", "8.4", "8.5"]
                 symfony: ["^6.4", "^7.4"]
 
         steps:


### PR DESCRIPTION
Add PHP 8.4 and 8.5 to the CI test matrix.

No changes needed in composer.json since `^8.2` already covers these versions.